### PR TITLE
Visit virtual cursors with virtualedit=onemore in insert/replace mode

### DIFF
--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -22,10 +22,10 @@ default_key_maps = {
   -- Left/right motion in normal/visual modes
   {{"n", "x"}, {"h", "<Left>"}, move.normal_h},
   {{"n", "x"}, "<BS>", move_special.normal_bs},
-  {{"n", "x"}, {"l", "<Right>", "<Space>"}, move_special.normal_l},
+  {{"n", "x"}, {"l", "<Right>", "<Space>"}, move.normal_l},
   {{"n", "x"}, "0", move.normal_0},
   {{"n", "x"}, "^", move.normal_caret},
-  {{"n", "x"}, "$", move_special.normal_dollar},
+  {{"n", "x"}, "$", move.normal_dollar},
   {{"n", "x"}, "|", move.normal_bar},
   {{"n", "x"}, "f", move.normal_f},
   {{"n", "x"}, "F", move.normal_F},
@@ -34,11 +34,11 @@ default_key_maps = {
 
   -- Left/right motion in insert/replace modes
   {"i", "<Left>", move.insert_left},
-  {"i", "<Right>", move_special.insert_right},
+  {"i", "<Right>", move.insert_right},
 
   -- Left/right motion in all modes
   {{"n", "i", "x"}, "<Home>", move.home},
-  {{"n", "i", "x"}, "<End>", move_special.eol},
+  {{"n", "i", "x"}, "<End>", move.eol},
 
   -- Up/down motion in normal/visual modes
   {{"n", "x"}, {"j", "<Down>"}, move_special.normal_j},

--- a/lua/multiple-cursors/insert_mode.lua
+++ b/lua/multiple-cursors/insert_mode.lua
@@ -2,7 +2,7 @@ local M = {}
 
 local common = require("multiple-cursors.common")
 local virtual_cursors = require("multiple-cursors.virtual_cursors")
-local move_special = require("multiple-cursors.move_special")
+
 
 -- Character to insert
 local char = nil

--- a/lua/multiple-cursors/move.lua
+++ b/lua/multiple-cursors/move.lua
@@ -10,9 +10,19 @@ function M.normal_h()
   virtual_cursors.move_with_normal_command("h", vim.v.count)
 end
 
+function M.normal_l()
+  common.feedkeys("l", vim.v.count)
+  virtual_cursors.move_with_normal_command("l", vim.v.count)
+end
+
 function M.normal_0()
   common.feedkeys("0", 0)
   virtual_cursors.move_with_normal_command("0", 0)
+end
+
+function M.normal_dollar()
+  common.feedkeys("$", 0)
+  virtual_cursors.move_with_normal_command("$", 0)
 end
 
 function M.normal_caret()
@@ -53,16 +63,26 @@ function M.normal_T()
   normal_fFtT("T")
 end
 
--- Left motion in insert/replace modes
+-- Left/right motion in insert/replace modes
 function M.insert_left()
   virtual_cursors.move_with_normal_command("h", 0)
   common.feedkeys("<Left>", 0)
 end
 
--- Home motion in all modes
+function M.insert_right()
+  virtual_cursors.move_with_normal_command("l", 0)
+  common.feedkeys("<Right>", 0)
+end
+
+-- Home/End motion in all modes
 function M.home()
   common.feedkeys("<Home>", 0)
   virtual_cursors.move_with_normal_command("0", 0)
+end
+
+function M.eol()
+  common.feedkeys("<End>", 0)
+  virtual_cursors.move_with_normal_command("$", 0)
 end
 
 -- Text object movement in normal/visual mode

--- a/lua/multiple-cursors/move_special.lua
+++ b/lua/multiple-cursors/move_special.lua
@@ -4,63 +4,6 @@ local common = require("multiple-cursors.common")
 local virtual_cursors = require("multiple-cursors.virtual_cursors")
 
 
--- Right -----------------------------------------------------------------------
-
--- Right command for a virtual cursor
-local function virtual_cursor_right(vc, count)
-  count = vim.fn.max({count, 1})
-  local col = vc.col + count
-  vc.col = common.get_col(vc.lnum, col)
-  vc.curswant = vc.col
-end
-
--- Right command for all virtual cursors
--- This isn't local because it's used in normal_mode_change
-function M.all_virtual_cursors_right(count)
-  virtual_cursors.visit_in_buffer(function(vc) virtual_cursor_right(vc, count) end)
-end
-
--- l command in normal/visual modes
-function M.normal_l()
-  common.feedkeys("l", vim.v.count)
-  M.all_virtual_cursors_right(vim.v.count)
-end
-
--- Right in insert/replace modes
-function M.insert_right()
-  common.feedkeys("<Right>", 0)
-  M.all_virtual_cursors_right(0)
-end
-
-
--- End-of-line -----------------------------------------------------------------
-
--- End-of-Line command for a virtual cursor
--- This isn't local because it's used by normal_mode_change
-function M.virtual_cursor_end(vc)
-  vc.col = common.get_col(vc.lnum, vim.v.maxcol)
-  vc.curswant = vim.v.maxcol
-end
-
--- End-of-Line command for all virtual cursors
--- This isn't local because it's used by normal_mode_change
-function M.all_virtual_cursors_end()
-  virtual_cursors.visit_in_buffer(function(vc) M.virtual_cursor_end(vc) end)
-end
-
--- $ command in normal/visual modes
-function M.normal_dollar()
-  common.feedkeys("$", 0)
-  M.all_virtual_cursors_end()
-end
-
--- EoL command in all modes
-function M.eol()
-  common.feedkeys("<End>", 0)
-  M.all_virtual_cursors_end()
-end
-
-
 -- Up --------------------------------------------------------------------------
 
 -- Determine the amount the real cursor will actually move up
@@ -209,19 +152,6 @@ function M.normal_underscore()
     common.feedkeys("_", vim.v.count)
     all_virtual_cursors_down(vim.v.count - 1)
     virtual_cursors.move_with_normal_command("^", 0)
-  end
-end
-
--- Normal mode $: EoL or down N lines to EoL
-function M.normal_dollar()
-  -- End of current line
-  if vim.v.count <= 1 then
-    common.feedkeys("$", vim.v.count)
-    virtual_cursors.move_with_normal_command("$", vim.v.count)
-  else -- Down N-1 lines
-    common.feedkeys("$", vim.v.count)
-    all_virtual_cursors_down(vim.v.count - 1)
-    virtual_cursors.move_with_normal_command("$", 0)
   end
 end
 

--- a/lua/multiple-cursors/normal_mode_change.lua
+++ b/lua/multiple-cursors/normal_mode_change.lua
@@ -2,7 +2,6 @@ local M = {}
 
 local common = require("multiple-cursors.common")
 local virtual_cursors = require("multiple-cursors.virtual_cursors")
-local move_special = require("multiple-cursors.move_special")
 local insert_mode = require("multiple-cursors.insert_mode")
 
 local mode_cmd = nil
@@ -15,16 +14,16 @@ function M.mode_changed()
     return
   elseif mode_cmd == "a" then
     -- Shift cursors right
-    move_special.all_virtual_cursors_right(0)
+    virtual_cursors.move_with_normal_command("l", 0)
   elseif mode_cmd == "A" then
     -- Cursors to end of line
-    move_special.all_virtual_cursors_end()
+    virtual_cursors.move_with_normal_command("$", 0)
   elseif mode_cmd == "I" then
     -- Cursor to start of line
     virtual_cursors.move_with_normal_command("^", 0)
   elseif mode_cmd == "o" then
     -- New line after current line
-    move_special.all_virtual_cursors_end()
+    virtual_cursors.move_with_normal_command("$", 0)
     insert_mode.all_virtual_cursors_carriage_return()
   elseif mode_cmd == "O" then
     -- New line before current line
@@ -34,7 +33,8 @@ function M.mode_changed()
         vc.curswant = 1
       else -- Move to end of previous line
         vc.lnum = vc.lnum - 1
-        move_special.virtual_cursor_end(vc)
+        vc.col = common.get_col(vc.lnum, vim.v.maxcol)
+        vc.curswant = vim.v.maxcol
       end
     end)
 

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -175,6 +175,13 @@ end
 -- Visit all virtual cursors
 function M.visit_all(func)
 
+  local ve = vim.wo.ve
+
+  -- Set virtualedit to onemore in insert or replace modes
+  if common.is_mode_insert_replace() then
+    vim.wo.ve = "onemore"
+  end
+
   for idx = 1, #virtual_cursors do
     local vc = virtual_cursors[idx]
 
@@ -191,6 +198,11 @@ function M.visit_all(func)
       extmarks.update_virtual_cursor_extmarks(vc)
     end
 
+  end
+
+  -- Revert virtualedit in insert or replace modes
+  if common.is_mode_insert_replace() then
+    vim.wo.ve = ve
   end
 
   clean_up()
@@ -233,6 +245,13 @@ function M.move_with_normal_command(cmd, count)
   M.visit_with_cursor(function(vc)
     common.normal_bang(cmd, count)
     common.set_virtual_cursor_from_cursor(vc)
+
+    -- Fix for $ not setting col correctly in insert mode even with onemore
+    if common.is_mode_insert_replace() then
+      if vc.curswant == vim.v.maxcol then
+        vc.col = common.get_max_col(vc.lnum)
+      end
+    end
   end)
 
 end


### PR DESCRIPTION
Visit virtual cursors with virtualedit=onemore in insert/replace mode so that the normal `l` and `$` commands can be used. `$` appears to not set col correctly so there is a fix for this.