### PR TITLE
Plugin compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ to bind the `MultipleCursorsAddDown` command to `Ctrl+Down` in normal and insert
 Add a section to the Lazy plugins table, e.g.:
 ```lua
 "brenton-leighton/multiple-cursors.nvim",
-opts = {},
+version = "*",  -- Use the latest tagged version
+opts = {},  -- This causes the plugin setup function to be called
 keys = {
   {"<C-Down>", "<Cmd>MultipleCursorsAddDown<CR>", mode = {"n", "i"}},
   {"<C-j>", "<Cmd>MultipleCursorsAddDown<CR>"},
@@ -118,6 +119,7 @@ Options can be configured by providing an options table to the setup function, e
 
 ```lua
 "brenton-leighton/multiple-cursors.nvim",
+version = "*",
 opts = {
   enable_split_paste = false,
   disabled_default_key_maps = {

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ This option allows for mapping keys to custom functions for use with multiple cu
 	- "m" indicates that a motion command is requested (i.e. operator pending mode). The motion command can can include a count in addition to the `count1` variable.
 	- "c" indicates that a printable character is requested (e.g. for character search)
 	- "mc" indicates that a motion command and a printable character is requested (e.g. for a surround action)
-	- "cc" indicates that two printable characters are requested
 	- If valid input isn't given by the user the function will not be called
 	- There will be no indication that Neovim is waiting for a motion command or character
 
@@ -207,11 +206,6 @@ opts = {
     {"n", "<Leader>b", function(register, count1, motion_cmd, char)
       vim.print(register .. count1 .. motion_cmd .. char)
     end, "mc"}
-
-    -- Two characters
-    {"n", "<Leader>d", function(register, count1, char1, char2)
-      vim.print(register .. count1 .. char1 .. char2)
-    end, "cc"}
 
   }
 }

--- a/README.md
+++ b/README.md
@@ -291,6 +291,23 @@ opts = {
 }
 ```
 
+### [mini.surround](https://github.com/echasnovski/mini.surround) and [kylechui/nvim-surround](https://github.com/kylechui/nvim-surround)
+
+Adds characters to surround text.
+The issue with both of these plugins is that they don't have functions that can be given the motion and character as arguments.
+
+One workaround would be to use a different key sequence to execute the command while using multiple cursors, e.g. for mini.pairs `sa` command:
+
+```lua
+custom_key_maps = {
+  {"n", "<Leader>sa", function(_, count1, motion_cmd, char)
+    vim.cmd("normal " .. count1 .. "sa" .. motion_cmd .. char)
+  end, "mc"},
+},
+```
+
+This would map `<Leader>sa` to work like `sa`.
+
 ## API
 
 ### `add_cursor(lnum, col, curswant)`

--- a/README.md
+++ b/README.md
@@ -232,7 +232,30 @@ opts = {
 
 ## Plugin compatibility
 
-### [`chrisgrieser/nvim-spider`](https://github.com/chrisgrieser/nvim-spider)
+### [windwp/nvim-autopairs](https://github.com/windwp/nvim-autopairs)
+
+Automatically inserts and deletes paired characters.
+There are a couple of issues with this plugin that mean it can't be installed along with multiple-cursors.nvim (the issues are that it creates mappings on the `InsertEnter` event, and that the mappings can't be overridden).
+An alternative is the [mini.pairs](#mini.pairs) plugin.
+
+### [mini.pairs](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pairs.md)
+
+Automatically inserts and deletes paired characters.
+If it were possible to call the plugin functions directly they could be mapped in `custom_key_maps`, but that doesn't seem to work.
+Therefore the plugin needs to be disabled while using multiple cursors:
+
+```lua
+opts = {
+  pre_hook = function()
+    vim.g.minipairs_disable = true
+  end,
+  post_hook = function()
+    vim.g.minipairs_disable = false
+  end,
+}
+```
+
+### [chrisgrieser/nvim-spider](https://github.com/chrisgrieser/nvim-spider)
 
 Improves `w`, `e`, and `b` motions. `count` must be set before the motion function is called.
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ This option allows for mapping keys to custom functions for use with multiple cu
 - Option: A optional string containing "m", "c", or "cc". These enable getting input from the user, which is then forwarded to the function:
 	- "m" indicates that a motion command is requested (i.e. operator pending mode). The motion command can can include a count in addition to the `count1` variable.
 	- "c" indicates that a printable character is requested (e.g. for character search)
+	- "mc" indicates that a motion command and a printable character is requested (e.g. for a surround action)
 	- "cc" indicates that two printable characters are requested
 	- If valid input isn't given by the user the function will not be called
 	- There will be no indication that Neovim is waiting for a motion command or character
@@ -189,22 +190,27 @@ opts = {
 
     -- No option
     {"n", "<Leader>a", function(register, count1)
-      vim.print(register .. count1 .. "a")
+      vim.print(register .. count1)
     end}
 
     -- Motion command
     {"n", "<Leader>b", function(register, count1, motion_cmd)
-      vim.print(register .. count1 .. "b" .. motion_cmd)
+      vim.print(register .. count1 .. motion_cmd)
     end, "m"}
 
     -- Character
     {"n", "<Leader>c", function(register, count1, char)
-      vim.print(register .. count1 .. "c" .. char)
+      vim.print(register .. count1 .. char)
     end, "c"}
+
+    -- Motion command then character
+    {"n", "<Leader>b", function(register, count1, motion_cmd, char)
+      vim.print(register .. count1 .. motion_cmd .. char)
+    end, "mc"}
 
     -- Two characters
     {"n", "<Leader>d", function(register, count1, char1, char2)
-      vim.print(register .. count1 .. "d" .. char1 .. char2)
+      vim.print(register .. count1 .. char1 .. char2)
     end, "cc"}
 
   }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 A multiple cursors plugin for Neovim that works the way multiple cursors work in other editors (such as Visual Studio Code or JetBrains IDEs). I.e. create extra cursors and then use Neovim as you normally would.
 
-Multiple cursors is a way of making edits at multiple positions, that's easier, faster, and/or more versatile than other methods available in Neovim (e.g. visual block mode or macros).
+Multiple cursors is a way of making edits at multiple positions, that's easier, faster, and/or more versatile than other methods available in Neovim (e.g. visual block mode, the repeat command, or macros). Cursors can be added with an up or down keyboard movement, a mouse click, or by finding matches to the word currently under the cursor.
+
+This plugin also has the ability to do "split pasting": if the number of lines of paste text matches the number of cursors, each line will be inserted at each cursor. This is only implmented for pasting, and not the put commands.
+
+The plugin works by overriding key mappings while multiple cursors are active. Any user defined key mappings will need to be added to the [custom_key_maps](#custom_key_maps) table to be used with multiple cursors.
+See the [Plugin compatibility](#plugin-compatibility) section for examples of how to work with specific plugins.
 
 ## Demos
 
@@ -10,7 +15,7 @@ Multiple cursors is a way of making edits at multiple positions, that's easier, 
 
 ![Basic usage](https://github.com/brenton-leighton/multiple-cursors.nvim/assets/12228142/4ea42343-6784-458c-aedb-f16b958551e3)
 
-### Pasting
+### Split pasting
 
 ![Copying multi-line text and pasting to each cursor](https://github.com/brenton-leighton/multiple-cursors.nvim/assets/12228142/2c063495-cf0a-4884-9c5a-9a3b86770c31)
 
@@ -86,7 +91,7 @@ After adding a new cursor the following functions are available:
 | Normal | Change to insert/replace mode | `a` `A` `i` `I` `o` `O` `R` | Count is ignored |
 | Insert/replace | Character insertion | | |
 | Insert/replace | Other edits | `<BS>` `<Del>` `<CR>` `<Tab>` | These commands are implemented manually, and may not behave correctly <br/> In replace mode `<BS>` will only move any virtual cursors back, and not undo edits |
-| Insert/replace | Paste | | By default if the number of lines in the paste text matches the number of cursors, each line of the text will be inserted at each cursor |
+| Insert/replace | Paste | | [Split pasting](#enable_split_paste) is enabled by default |
 | Insert | Change to replace mode | `<Insert>` | |
 | Normal | Change to visual mode | `v` | |
 | Visual | Swap cursor to other end of visual area | `o` | |
@@ -168,11 +173,13 @@ This option allows for mapping keys to custom functions for use with multiple cu
 - Mapping lhs (string|table): [Left-hand side](https://neovim.io/doc/user/map.html#%7Blhs%7D) of a mapping string, e.g. `">>"`, `"<Tab>"`, or `"<C-/>"`, or a table of lhs strings
 - Function: A Lua function that will be called at each cursor, which receives [`register`](https://neovim.io/doc/user/vvars.html#v%3Aregister) and [`count1`](https://neovim.io/doc/user/vvars.html#v%3Acount1) as arguments
 - Option: A optional string containing "m", "c", or "cc". These enable getting input from the user, which is then forwarded to the function:
-	- "m" indicates that a motion command (which can include a count in addition to the `count1` variable) is requested (i.e. operator pending mode)
+	- "m" indicates that a motion command is requested (i.e. operator pending mode). The motion command can can include a count in addition to the `count1` variable.
 	- "c" indicates that a printable character is requested (e.g. for character search)
 	- "cc" indicates that two printable characters are requested
 	- If valid input isn't given by the user the function will not be called
 	- There will be no indication that Neovim is waiting for a motion command or character
+
+Example usage:
 
 ```lua
 opts = {
@@ -210,7 +217,7 @@ Default values: `nil`
 
 These options are to provide functions that are called a the start of initialisation and at the end of de-initialisation respectively.
 
-E.g. to disable `cursorline` while multiple cursors are active:
+E.g. to disable [`cursorline`](https://neovim.io/doc/user/options.html#'cursorline') while multiple cursors are active:
 
 ```lua
 opts = {
@@ -227,7 +234,7 @@ opts = {
 
 ### [`chrisgrieser/nvim-spider`](https://github.com/chrisgrieser/nvim-spider)
 
-Improves `w`, `e`, and `b` motions. `count1` must be set before the motion function is called.
+Improves `w`, `e`, and `b` motions. `count` must be set before the motion function is called.
 
 ```lua
 opts = {

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -123,24 +123,8 @@ default_key_maps = {
   {"x", "o", visual_mode.o},
 
   -- Modify visual area
-  {"x", "aw", visual_mode.aw},
-  {"x", "iw", visual_mode.iw},
-  {"x", "aW", visual_mode.aW},
-  {"x", "iW", visual_mode.iW},
-  {"x", "ab", visual_mode.ab},
-  {"x", "ib", visual_mode.ib},
-  {"x", "aB", visual_mode.aB},
-  {"x", "iB", visual_mode.iB},
-  {"x", "a>", visual_mode.a_greater_than},
-  {"x", "i>", visual_mode.i_greater_than},
-  {"x", "at", visual_mode.at},
-  {"x", "it", visual_mode.it},
-  {"x", [[a']], visual_mode.a_quote},
-  {"x", [[i']], visual_mode.i_quote},
-  {"x", [[a"]], visual_mode.a_double_quote},
-  {"x", [[i"]], visual_mode.i_double_quote},
-  {"x", "a`", visual_mode.a_backtick},
-  {"x", "i`", visual_mode.i_backtick},
+  {"x", "a", visual_mode.a},
+  {"x", "i", visual_mode.i},
 
   -- Join lines in visual mode
   {"x", "J", visual_mode.J},

--- a/lua/multiple-cursors/input.lua
+++ b/lua/multiple-cursors/input.lua
@@ -60,6 +60,30 @@ local search_motions = {
   ["T"] = true,
 }
 
+-- The second character in a text object selection
+local text_object_selections = {
+
+  ["w"] = true,
+  ["W"] = true,
+  ["s"] = true,
+  ["p"] = true,
+  ["]"] = true,
+  ["["] = true,
+  [")"] = true,
+  ["("] = true,
+  ["b"] = true,
+  ["B"] = true,
+  [">"] = true,
+  ["<"] = true,
+  ["t"] = true,
+  ["}"] = true,
+  ["{"] = true,
+  ["\'"] = true,
+  ["\""] = true,
+  ["`"] = true,
+
+}
+
 -- Get a standard character and returns nil for anything else
 function M.get_char()
 
@@ -99,9 +123,21 @@ function M.get_two_chars()
 
 end
 
+-- Get the second character of a text object selection
+function M.get_text_object_sel_second_char()
+  local char = vim.fn.getcharstr()
+
+  -- If the character is a valid text object selection second character
+  if text_object_selections[char] then
+    return char
+  end
+
+  return nil
+end
+
 -- Wait for a motion command
--- Returns a normal motion command (which may inclue a count) or nil if no valid
--- motion was given
+-- Returns a normal motion command (which may include a count) or nil if no
+-- valid motion was given
 function M.get_motion_cmd()
 
   -- Wait for a character
@@ -125,16 +161,26 @@ function M.get_motion_cmd()
 
     if char then -- Valid character
       return count .. motion_char .. char
-    else
-      return nil
     end
+
+    return nil
+  end
+
+  -- If the character is a text object selection first character
+  if motion_char == "a" or motion_char == "i" then
+    -- Get a text object selection second character
+    local char2 = M.get_text_object_sel_second_char()
+
+    if char2 then
+      return count .. motion_char .. char2
+    end
+
+    return nil
   end
 
   -- If the character is a valid motion
   if motions[motion_char] then
     return count .. motions[motion_char]
-  else
-    return nil
   end
 
   return nil

--- a/lua/multiple-cursors/key_maps.lua
+++ b/lua/multiple-cursors/key_maps.lua
@@ -223,30 +223,6 @@ local function custom_function_with_motion_then_char(func)
 
 end
 
-local function custom_function_with_two_chars(func)
-
-  -- Save register and count1 because they may be lost
-  local register = vim.v.register
-  local count1 = vim.v.count1
-
-  -- Get two printable characters
-  local char1, char2 = input.get_two_chars()
-
-  if char1 == nil or char2 == nil then
-    return
-  end
-
-  -- Call func for the real cursor
-  func(register, count1, char1, char2)
-
-  -- Call func for each virtual cursor and set the virtual cursor position
-  virtual_cursors.edit_with_cursor(function(vc)
-    func(register, count1, char1, char2)
-    vc:save_cursor_position()
-  end)
-
-end
-
 -- Set any custom key maps
 -- This is a separate function because it's also used by the LazyLoad autocmd
 function M.set_custom()
@@ -271,8 +247,6 @@ function M.set_custom()
         wrapped_func = function() custom_function_with_char(func) end
       elseif opt == "mc" then -- Standard character
         wrapped_func = function() custom_function_with_motion_then_char(func) end
-      elseif opt == "cc" then -- Two standard characters
-        wrapped_func = function() custom_function_with_two_chars(func) end
       end
     end
 

--- a/lua/multiple-cursors/key_maps.lua
+++ b/lua/multiple-cursors/key_maps.lua
@@ -150,7 +150,7 @@ local function custom_function_with_motion(func)
   local register = vim.v.register
   local count1 = vim.v.count1
 
-  -- Get a printable character
+  -- Get a motion command
   local motion_cmd = input.get_motion_cmd()
 
   if motion_cmd == nil then
@@ -187,6 +187,37 @@ local function custom_function_with_char(func)
   -- Call func for each virtual cursor and set the virtual cursor position
   virtual_cursors.edit_with_cursor(function(vc)
     func(register, count1, char)
+    vc:save_cursor_position()
+  end)
+
+end
+
+local function custom_function_with_motion_then_char(func)
+
+  -- Save register and count1 because they may be lost
+  local register = vim.v.register
+  local count1 = vim.v.count1
+
+  -- Get a motion command
+  local motion_cmd = input.get_motion_cmd()
+
+  if motion_cmd == nil then
+    return
+  end
+
+  -- Get a printable character
+  local char = input.get_char()
+
+  if char == nil then
+    return
+  end
+
+  -- Call func for the real cursor
+  func(register, count1, motion_cmd, char)
+
+  -- Call func for each virtual cursor and set the virtual cursor position
+  virtual_cursors.edit_with_cursor(function(vc)
+    func(register, count1, motion_cmd, char)
     vc:save_cursor_position()
   end)
 
@@ -238,6 +269,8 @@ function M.set_custom()
         wrapped_func = function() custom_function_with_motion(func) end
       elseif opt == "c" then -- Standard character
         wrapped_func = function() custom_function_with_char(func) end
+      elseif opt == "mc" then -- Standard character
+        wrapped_func = function() custom_function_with_motion_then_char(func) end
       elseif opt == "cc" then -- Two standard characters
         wrapped_func = function() custom_function_with_two_chars(func) end
       end

--- a/lua/multiple-cursors/visual_mode.lua
+++ b/lua/multiple-cursors/visual_mode.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local common = require("multiple-cursors.common")
 local virtual_cursors = require("multiple-cursors.virtual_cursors")
+local input = require("multiple-cursors.input")
 
 -- Escape command
 function M.escape()
@@ -29,25 +30,32 @@ local function modify_area(cmd)
   common.feedkeys(nil, count, cmd, nil)
 end
 
-function M.o() modify_area("o") end
-function M.aw() modify_area("aw") end
-function M.iw() modify_area("iw") end
-function M.aW() modify_area("aW") end
-function M.iW() modify_area("iW") end
-function M.ab() modify_area("ab") end
-function M.ib() modify_area("ib") end
-function M.aB() modify_area("aB") end
-function M.iB() modify_area("iB") end
-function M.a_greater_than() modify_area("a>") end
-function M.i_greater_than() modify_area("i>") end
-function M.at() modify_area("at") end
-function M.it() modify_area("it") end
-function M.a_quote() modify_area([[a']]) end
-function M.i_quote() modify_area([[i']]) end
-function M.a_double_quote() modify_area([[a"]]) end
-function M.i_double_quote() modify_area([[i"]]) end
-function M.a_backtick() modify_area("a`") end
-function M.i_backtick() modify_area("i`") end
+-- o command
+function M.o()
+  modify_area("o")
+end
+
+-- "a" text object selection commands
+function M.a()
+  local char2 = input.get_text_object_sel_second_char()
+
+  if char2 then
+    modify_area("a" .. char2)
+  end
+
+  return
+end
+
+-- "i" text object selection commands
+function M.i()
+  local char2 = input.get_text_object_sel_second_char()
+
+  if char2 then
+    modify_area("i" .. char2)
+  end
+
+  return
+end
 
 
 -- Edit ------------------------------------------------------------------------


### PR DESCRIPTION
- Add information on compatibility with autopair and surround plugins
- Add "mc" (motion command then character) for custom key maps
- Handle text object selection motion commands, and use it for visual mode modify area commands
- Remove the "cc" (two printable characters) for custom key maps