### PR TITLE
Feat visual cursor word

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # multiple-cursors.nvim
 
-A multiple cursors plugin for Neovim that works the way multiple cursors work in other editors (such as Visual Studio Code or JetBrains IDEs). I.e. create extra cursors and then use Neovim as you normally would.
+A multiple cursors plugin for Neovim that works the way multiple cursors work in other editors (such as Visual Studio Code or JetBrains IDEs).
+I.e. create extra cursors and then use Neovim as you normally would.
+Cursors can be added with an up/down movement, with a mouse click, or to matches to the word under the cursor.
 
-Multiple cursors is a way of making edits at multiple positions, that's easier, faster, and/or more versatile than other methods available in Neovim (e.g. visual block mode, the repeat command, or macros). Cursors can be added with an up or down keyboard movement, a mouse click, or by finding matches to the word currently under the cursor.
+This plugin also has the ability to do "split pasting": if the number of lines of paste text matches the number of cursors, each line will be inserted at each cursor (this is only implemented for pasting, and not the put commands).
 
-This plugin also has the ability to do "split pasting": if the number of lines of paste text matches the number of cursors, each line will be inserted at each cursor. This is only implmented for pasting, and not the put commands.
-
-The plugin works by overriding key mappings while multiple cursors are active. Any user defined key mappings will need to be added to the [custom_key_maps](#custom_key_maps) table to be used with multiple cursors.
+The plugin works by overriding key mappings while multiple cursors are active.
+Any user defined key mappings will need to be added to the [custom_key_maps](#custom_key_maps) table to be used with multiple cursors.
 See the [Plugin compatibility](#plugin-compatibility) section for examples of how to work with specific plugins.
 
 ## Demos
@@ -32,7 +33,8 @@ The plugin doesn't initially bind any keys, but creates three commands:
 | `MultipleCursorsAddDown` | Add a new virtual cursor, then move the real cursor down |
 | `MultipleCursorsAddUp` | Add a new virtual cursor, then move the real cursor up |
 | `MultipleCursorsMouseAddDelete` | Add a new virtual cursor to the mouse click position, unless there is already a virtual cursor at the mouse click position, in which case it is removed |
-| `MultipleCursorsAddToWordUnderCursor` | Search for the word under the cursor and add cursors to each match. <br/> If called in visual mode, the visual area is saved and visual mode is exited. When the command is next called in normal mode, cursors will be added to only the matching words that begin within the saved visual area. |
+| `MultipleCursorsAddToCword` | Search for the word under the cursor and add cursors to each match |
+| `MultipleCursorsAddToCwordV` | Search for the word under the cursor and add cursors to each match within the previous visual area |
 
 These commands can be bound to keys, e.g.:
 ```lua
@@ -55,7 +57,8 @@ keys = {
   {"<C-Up>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "i"}},
   {"<C-k>", "<Cmd>MultipleCursorsAddUp<CR>"},
   {"<C-LeftMouse>", "<Cmd>MultipleCursorsMouseAddDelete<CR>", mode = {"n", "i"}},
-  {"<Leader>a", "<Cmd>MultipleCursorsAddToWordUnderCursor<CR>", mode = {"n", "v"}},
+  {"<Leader>a", "<Cmd>MultipleCursorsAddToCword<CR>", mode = "n"},
+  {"<Leader>A", "<Cmd>MultipleCursorsAddToCwordV<CR>", mode = "n"},
 },
 ```
 
@@ -66,7 +69,8 @@ This configures the plugin with the default options, and sets the following key 
 - `Ctrl+Up` in normal and insert modes: `MultipleCursorsAddUp`
 - `Ctrl+k` in normal mode: `MultipleCursorsAddUp`
 - `Ctrl+LeftClick` in normal and insert modes: `MultipleCursorsMouseAddDelete`
-- `Leader+a` in normal and visual modes: `MultipleCursorsAddToWordUnderCursor` (note: `<Leader>` must have been set previously)
+- `Leader+a` in normal mode: `MultipleCursorsAddToCword` (note: `<Leader>` must have been set previously)
+- `Leader+A` in normal mode: `MultipleCursorsAddToCwordV`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A multiple cursors plugin for Neovim that works the way multiple cursors work in other editors (such as Visual Studio Code or JetBrains IDEs).
 I.e. create extra cursors and then use Neovim as you normally would.
-Cursors can be added with an up/down movement, with a mouse click, or to matches to the word under the cursor.
+Cursors can be added with an up/down movement, with a mouse click, or by searching for a pattern.
 
 This plugin also has the ability to do "split pasting": if the number of lines of paste text matches the number of cursors, each line will be inserted at each cursor (this is only implemented for pasting, and not the put commands).
 
@@ -33,8 +33,8 @@ The plugin doesn't initially bind any keys, but creates three commands:
 | `MultipleCursorsAddDown` | Add a new virtual cursor, then move the real cursor down |
 | `MultipleCursorsAddUp` | Add a new virtual cursor, then move the real cursor up |
 | `MultipleCursorsMouseAddDelete` | Add a new virtual cursor to the mouse click position, unless there is already a virtual cursor at the mouse click position, in which case it is removed |
-| `MultipleCursorsAddToCword` | Search for the word under the cursor and add cursors to each match |
-| `MultipleCursorsAddToCwordV` | Search for the word under the cursor and add cursors to each match within the previous visual area |
+| `MultipleCursorsAddBySearch` | Search for the word under the cursor (in normal mode) or the visual area (in visual mode) and add cursors to each match |
+| `MultipleCursorsAddBySearchV` | As above, but limit matches to the previous visual area |
 
 These commands can be bound to keys, e.g.:
 ```lua
@@ -57,8 +57,8 @@ keys = {
   {"<C-Up>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "i"}},
   {"<C-k>", "<Cmd>MultipleCursorsAddUp<CR>"},
   {"<C-LeftMouse>", "<Cmd>MultipleCursorsMouseAddDelete<CR>", mode = {"n", "i"}},
-  {"<Leader>a", "<Cmd>MultipleCursorsAddToCword<CR>", mode = "n"},
-  {"<Leader>A", "<Cmd>MultipleCursorsAddToCwordV<CR>", mode = "n"},
+  {"<Leader>a", "<Cmd>MultipleCursorsAddBySearch<CR>", mode = {"n", "x"}},
+  {"<Leader>A", "<Cmd>MultipleCursorsAddBySearchV<CR>", mode = {"n", "x"}},
 },
 ```
 
@@ -69,8 +69,8 @@ This configures the plugin with the default options, and sets the following key 
 - `Ctrl+Up` in normal and insert modes: `MultipleCursorsAddUp`
 - `Ctrl+k` in normal mode: `MultipleCursorsAddUp`
 - `Ctrl+LeftClick` in normal and insert modes: `MultipleCursorsMouseAddDelete`
-- `Leader+a` in normal mode: `MultipleCursorsAddToCword` (note: `<Leader>` must have been set previously)
-- `Leader+A` in normal mode: `MultipleCursorsAddToCwordV`
+- `Leader+a` in normal and visual modes: `MultipleCursorsAddBySearch` (note: `<Leader>` must have been set previously)
+- `Leader+A` in normal and visual modes: `MultipleCursorsAddBySearchV`
 
 ## Usage
 

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -332,27 +332,8 @@ function M.mouse_add_delete_cursor()
   end
 end
 
--- Add a new cursor at given position
-function M.add_cursor(lnum, col, curswant)
-
-  -- Initialise if this is the first cursor
-  M.init()
-
-  -- Add a virtual cursor
-  virtual_cursors.add(lnum, col, curswant)
-
-end
-
--- Add cursors to each instance of the word under the real cursor
-function M.add_cursors_to_word_under_cursor()
-
-  -- If visual mode
-  if common.is_mode("v") then
-    -- Just exit visual mode and save the area
-    vim.cmd("normal!:")
-    search.save_previous_visual_area()
-    return
-  end
+-- Add cursors to each match of the word under the real cursor
+local function _add_cursors_to_cword(use_prev_visual_area)
 
   local word = vim.fn.expand("<cword>")
 
@@ -362,7 +343,7 @@ function M.add_cursors_to_word_under_cursor()
   end
 
   -- Find matches (without the one for the cursor) and move the cursor to its match
-  local matches = search.get_matches_and_move_cursor(word)
+  local matches = search.get_matches_and_move_cursor(word, use_prev_visual_area)
 
   if matches == nil then
     return
@@ -378,6 +359,24 @@ function M.add_cursors_to_word_under_cursor()
   end
 
   vim.print(#matches .. " cursors added")
+
+end
+
+-- Add cursors to each match of the word under the real cursor
+function M.add_cursors_to_cword() _add_cursors_to_cword(false) end
+
+-- Add cursors to each match of the word under the real cursor, only within the
+-- previous visual area
+function M.add_cursors_to_cword_v() _add_cursors_to_cword(true) end
+
+-- Add a new cursor at given position
+function M.add_cursor(lnum, col, curswant)
+
+  -- Initialise if this is the first cursor
+  M.init()
+
+  -- Add a virtual cursor
+  virtual_cursors.add(lnum, col, curswant)
 
 end
 
@@ -414,7 +413,8 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("MultipleCursorsAddDown", M.add_cursor_down, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddUp", M.add_cursor_up, {})
   vim.api.nvim_create_user_command("MultipleCursorsMouseAddDelete", M.mouse_add_delete_cursor, {})
-  vim.api.nvim_create_user_command("MultipleCursorsAddToWordUnderCursor", M.add_cursors_to_word_under_cursor, {})
+  vim.api.nvim_create_user_command("MultipleCursorsAddToCword", M.add_cursors_to_cword, {})
+  vim.api.nvim_create_user_command("MultipleCursorsAddToCwordV", M.add_cursors_to_cword_v, {})
 
 end
 

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -332,21 +332,73 @@ function M.mouse_add_delete_cursor()
   end
 end
 
--- Add cursors to each match of the word under the real cursor
-local function _add_cursors_to_cword(use_prev_visual_area)
+-- Get the current visual area normalised
+local function get_visual_area()
+  local v_lnum = vim.fn.line("v")
+  local v_col = vim.fn.col("v")
+  local c_lnum = vim.fn.line(".")
+  local c_col = vim.fn.col(".")
 
-  local word = vim.fn.expand("<cword>")
+  if v_lnum == 0 or v_col == 0  or c_lnum == 0 or c_col == 0 then
+    return nil
+  end
 
-  -- No word under cursor
-  if word == "" then
+  -- Normalise
+  if v_lnum < c_lnum then
+    return v_lnum, v_col, c_lnum, c_col
+  elseif c_lnum < v_lnum then
+    return c_lnum, c_col, v_lnum, v_col
+  else -- v_lnum == c_lnum
+    if v_col <= c_col then
+      return v_lnum, v_col, c_lnum, c_col
+    else -- c_col < v_col
+      return c_lnum, c_col, v_lnum, v_col
+    end
+  end
+end
+
+local function get_visual_area_text()
+
+ local lnum1, col1, lnum2, col2 = get_visual_area()
+
+  if lnum1 ~= lnum2 then
+    vim.print("Search pattern must be a single line")
+    return nil
+  end
+
+  local line = vim.fn.getline(lnum1)
+  return line:sub(col1, col2)
+
+end
+
+-- Add cursors by searching for the word under the cursor or visual area
+local function _add_cursors_by_search(use_prev_visual_area)
+
+  local pattern = nil
+
+  if common.is_mode("v") then
+    pattern = get_visual_area_text()
+  else
+    -- Use the word under the cursor
+    pattern = vim.fn.expand("<cword>")
+  end
+
+  -- No pattern
+  if not pattern or pattern == "" then
     return
   end
 
   -- Find matches (without the one for the cursor) and move the cursor to its match
-  local matches = search.get_matches_and_move_cursor(word, use_prev_visual_area)
+  local matches = search.get_matches_and_move_cursor(pattern, use_prev_visual_area)
 
   if matches == nil then
+    vim.print("No matches found")
     return
+  end
+
+  -- Exit visual mode
+  if common.is_mode("v") then
+    vim.cmd("normal!:")
   end
 
   -- Initialise if not already initialised
@@ -363,11 +415,11 @@ local function _add_cursors_to_cword(use_prev_visual_area)
 end
 
 -- Add cursors to each match of the word under the real cursor
-function M.add_cursors_to_cword() _add_cursors_to_cword(false) end
+function M.add_cursors_by_search() _add_cursors_by_search(false) end
 
 -- Add cursors to each match of the word under the real cursor, only within the
 -- previous visual area
-function M.add_cursors_to_cword_v() _add_cursors_to_cword(true) end
+function M.add_cursors_by_search_v() _add_cursors_by_search(true) end
 
 -- Add a new cursor at given position
 function M.add_cursor(lnum, col, curswant)
@@ -413,8 +465,8 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("MultipleCursorsAddDown", M.add_cursor_down, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddUp", M.add_cursor_up, {})
   vim.api.nvim_create_user_command("MultipleCursorsMouseAddDelete", M.mouse_add_delete_cursor, {})
-  vim.api.nvim_create_user_command("MultipleCursorsAddToCword", M.add_cursors_to_cword, {})
-  vim.api.nvim_create_user_command("MultipleCursorsAddToCwordV", M.add_cursors_to_cword_v, {})
+  vim.api.nvim_create_user_command("MultipleCursorsAddBySearch", M.add_cursors_by_search, {})
+  vim.api.nvim_create_user_command("MultipleCursorsAddBySearchV", M.add_cursors_by_search_v, {})
 
 end
 

--- a/lua/multiple-cursors/search.lua
+++ b/lua/multiple-cursors/search.lua
@@ -5,37 +5,47 @@ local virtual_cursors = require("multiple-cursors.virtual_cursors")
 -- Only add cursors to matches that are visible
 local match_visible_only = true
 
--- For saving the visual area
-local visual_area_start = nil
-local visual_area_end = nil
-
 function M.setup(_match_visible_only)
   match_visible_only = _match_visible_only
 end
 
-function M.save_previous_visual_area()
-  visual_area_start = vim.api.nvim_buf_get_mark(0, "<")
-  visual_area_end = vim.api.nvim_buf_get_mark(0, ">")
-end
+-- Returns positions for matches to the given word
+-- If use_prev_visual_area is true, only matches within the previous visual area
+-- are returned
+-- If match_visible_only is true, only matches within the visible buffer are
+-- returned
+function M.get_matches_and_move_cursor(word, use_prev_visual_area)
 
-function M.get_matches_and_move_cursor(word)
-
-  -- Save real cursor
+  -- Save real cursor position
   local cursor_pos = vim.fn.getcurpos()
 
   virtual_cursors.set_ignore_cursor_movement(true)
 
-  -- If there's a saved visual area
-  if visual_area_start then
+  -- Handle the use_prev_visual_area argument
+  local visual_area_end = nil
+
+  if use_prev_visual_area then
+    -- Get the previous visual area
+    local visual_area_start = vim.api.nvim_buf_get_mark(0, "<")
+    visual_area_end = vim.api.nvim_buf_get_mark(0, ">")
+
+    if visual_area_start[1] == 0 or visual_area_start[2] == 0 or visual_area_end[1] == 0 or visual_area_end[2] == 0 then
+      vim.print("No previous visual area")
+      return
+    end
+
     -- Move the cursor to the start of the visual area
     vim.fn.cursor({visual_area_start[1], visual_area_start[2] + 1, 0, visual_area_start[2] + 1})
+
   elseif match_visible_only then
     -- Move cursor to start of the visible buffer
     local start_lnum = vim.fn.line("w0")
     vim.fn.cursor({start_lnum, 1, 0, 1})
+
   else
     -- Move the cursor to the start of the buffer
     vim.fn.cursor({1, 1, 0, 1})
+
   end
 
   -- Find matches
@@ -59,28 +69,25 @@ function M.get_matches_and_move_cursor(word)
       break
     end
 
-    -- If there's a visual area
-    if visual_area_start then
+    if use_prev_visual_area then
       -- End if the match is past the visual area
       if match[1] > visual_area_end[1] or
           (match[1] == visual_area_end[1] and match[2] > visual_area_end[2] + 1) then
         break
       end
+
     elseif match_visible_only then
       -- No visual area and matching visible only
       if match[1] > visible_end_lnum then
         -- Past the visible buffer
         break
       end
+
     end
 
     -- Add the match
     table.insert(matches, match)
   end
-
-  -- Clear any saved visual area
-  visual_area_start = nil
-  visual_area_end = nil
 
   -- If there is one or no matches
   if #matches <= 1 then


### PR DESCRIPTION
This merge replaces the command `MultipleCursorsAddToWordUnderCursor` with two commands: `MultipleCursorsAddBySearch` and `MultipleCursorsAddBySearchV`.

`MultipleCursorsAddBySearch` will add cursors by searching for the word under the cursor in normal mode, and by searching for the text of the visual area in visual mode.

`MultipleCursorsAddBySearchV` is identical to `MultipleCursorsAddBySearch`, except that it will limit the search to the previous visual area.