### PR TITLE
Use count rather than count1 for custom key maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,7 @@ The plugin works by overriding key mappings while multiple cursors are active.
 Any user defined key mappings will need to be added to the [custom_key_maps](#custom_key_maps) table to be used with multiple cursors.
 See the [Plugin compatibility](#plugin-compatibility) section for examples of how to work with specific plugins.
 
-## Demos
-
-### Basic usage
-
 ![Basic usage](https://github.com/brenton-leighton/multiple-cursors.nvim/assets/12228142/4ea42343-6784-458c-aedb-f16b958551e3)
-
-### Split pasting
-
-![Copying multi-line text and pasting to each cursor](https://github.com/brenton-leighton/multiple-cursors.nvim/assets/12228142/2c063495-cf0a-4884-9c5a-9a3b86770c31)
-
-### Creating cursors from the word under the cursor
-
-![Creating cursors from the word under the cursor](https://github.com/brenton-leighton/multiple-cursors.nvim/assets/12228142/1c4c59f6-7e15-4993-a7ca-cadfdc8e9901)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ Default value: `{}`
 
 This option allows for mapping keys to custom functions for use with multiple cursors. Each element in the `custom_key_maps` table must have three or four elements:
 
-- Mode (string|table): Mode short-name string (`"n"` or `"i"`), or a table of mode short-name strings (custom key maps are not currently working in visual mode).
+- Mode (string|table): Mode short-name string (`"n"`, `"i"` or `"x"`), or a table of mode short-name strings (for visual mode it's currently only possible to move the cursor)
 - Mapping lhs (string|table): [Left-hand side](https://neovim.io/doc/user/map.html#%7Blhs%7D) of a mapping string, e.g. `">>"`, `"<Tab>"`, or `"<C-/>"`, or a table of lhs strings
-- Function: A Lua function that will be called at each cursor, which receives [`register`](https://neovim.io/doc/user/vvars.html#v%3Aregister) and [`count1`](https://neovim.io/doc/user/vvars.html#v%3Acount1) as arguments
+- Function: A Lua function that will be called at each cursor, which receives [`register`](https://neovim.io/doc/user/vvars.html#v%3Aregister) and [`count`](https://neovim.io/doc/user/vvars.html#v%3Acount) as arguments
 - Option: A optional string containing "m", "c", or "cc". These enable getting input from the user, which is then forwarded to the function:
-	- "m" indicates that a motion command is requested (i.e. operator pending mode). The motion command can can include a count in addition to the `count1` variable.
+	- "m" indicates that a motion command is requested (i.e. operator pending mode). The motion command can can include a count in addition to the `count` variable.
 	- "c" indicates that a printable character is requested (e.g. for character search)
 	- "mc" indicates that a motion command and a printable character is requested (e.g. for a surround action)
 	- If valid input isn't given by the user the function will not be called
@@ -192,23 +192,23 @@ opts = {
   custom_key_maps = {
 
     -- No option
-    {"n", "<Leader>a", function(register, count1)
-      vim.print(register .. count1)
+    {"n", "<Leader>a", function(register, count)
+      vim.print(register .. count)
     end}
 
     -- Motion command
-    {"n", "<Leader>b", function(register, count1, motion_cmd)
-      vim.print(register .. count1 .. motion_cmd)
+    {"n", "<Leader>b", function(register, count, motion_cmd)
+      vim.print(register .. count .. motion_cmd)
     end, "m"}
 
     -- Character
-    {"n", "<Leader>c", function(register, count1, char)
-      vim.print(register .. count1 .. char)
+    {"n", "<Leader>c", function(register, count, char)
+      vim.print(register .. count .. char)
     end, "c"}
 
     -- Motion command then character
-    {"n", "<Leader>b", function(register, count1, motion_cmd, char)
-      vim.print(register .. count1 .. motion_cmd .. char)
+    {"n", "<Leader>b", function(register, count, motion_cmd, char)
+      vim.print(register .. count .. motion_cmd .. char)
     end, "mc"}
 
   }
@@ -263,26 +263,32 @@ opts = {
 
 ### [chrisgrieser/nvim-spider](https://github.com/chrisgrieser/nvim-spider)
 
-Improves `w`, `e`, and `b` motions. `count` must be set before the motion function is called.
+Improves `w`, `e`, and `b` motions. In normal mode `count` must be set before the motion function is called.
 
 ```lua
 opts = {
   custom_key_maps = {
     -- w
-    {"n", "w", function(_, count1)
-      vim.cmd("normal! " .. count1)
+    {{"n", "x"}, "w", function(_, count)
+      if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
+        vim.cmd("normal! " .. count)
+      end
       require('spider').motion('w')
     end},
 
     -- e
-    {"n", "e", function(_, count1)
-      vim.cmd("normal! " .. count1)
+    {{"n", "x"}, "e", function(_, count)
+      if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
+        vim.cmd("normal! " .. count)
+      end
       require('spider').motion('e')
     end},
 
     -- b
-    {"n", "b", function(_, count1)
-      vim.cmd("normal! " .. count1)
+    {{"n", "x"}, "b", function(_, count)
+      if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
+        vim.cmd("normal! " .. count)
+      end
       require('spider').motion('b')
     end},
   }
@@ -298,8 +304,8 @@ One workaround would be to use a different key sequence to execute the command w
 
 ```lua
 custom_key_maps = {
-  {"n", "<Leader>sa", function(_, count1, motion_cmd, char)
-    vim.cmd("normal " .. count1 .. "sa" .. motion_cmd .. char)
+  {"n", "<Leader>sa", function(_, count, motion_cmd, char)
+    vim.cmd("normal " .. count .. "sa" .. motion_cmd .. char)
   end, "mc"},
 },
 ```

--- a/README.md
+++ b/README.md
@@ -312,6 +312,18 @@ custom_key_maps = {
 
 This would map `<Leader>sa` to work like `sa`.
 
+### [gbprod/stay-in-place.nvim](https://github.com/gbprod/stay-in-place.nvim)
+
+Maintain cursor position when indenting and unindenting.
+
+```lua
+custom_key_maps = {
+  {"n", {">>", "<Tab>"}, function() require("stay-in-place").shift_right_line() end},
+  {"n", "<<", function() require("stay-in-place").shift_left_line() end},
+  {{"n", "i"}, "<S-Tab>", function() require("stay-in-place").shift_left_line() end},
+},
+```
+
 ## API
 
 ### `add_cursor(lnum, col, curswant)`

--- a/README.md
+++ b/README.md
@@ -229,9 +229,11 @@ E.g. to disable [`cursorline`](https://neovim.io/doc/user/options.html#'cursorli
 opts = {
   pre_hook = function()
     vim.opt.cursorline = false
+    vim.cmd("NoMatchParen")
   end,
   post_hook = function()
     vim.opt.cursorline = true
+    vim.cmd("DoMatchParen")
   end,
 }
 ```

--- a/lua/multiple-cursors/key_maps.lua
+++ b/lua/multiple-cursors/key_maps.lua
@@ -130,25 +130,25 @@ end
 -- Function to execute a custom key map
 local function custom_function(func)
 
-  -- Save register and count1 because they may be lost
+  -- Save register and count because they may be lost
   local register = vim.v.register
-  local count1 = vim.v.count1
+  local count = vim.v.count
 
   -- Call func for the real cursor
-  func(register, count1)
+  func(register, count)
 
   -- Call func for each virtual cursor and set the virtual cursor position
   virtual_cursors.edit_with_cursor(function(vc)
-    func(register, count1)
+    func(register, count)
     vc:save_cursor_position()
   end)
 end
 
 local function custom_function_with_motion(func)
 
-  -- Save register and count1 because they may be lost
+  -- Save register and count because they may be lost
   local register = vim.v.register
-  local count1 = vim.v.count1
+  local count = vim.v.count
 
   -- Get a motion command
   local motion_cmd = input.get_motion_cmd()
@@ -158,11 +158,11 @@ local function custom_function_with_motion(func)
   end
 
   -- Call func for the real cursor
-  func(register, count1, motion_cmd)
+  func(register, count, motion_cmd)
 
   -- Call func for each virtual cursor and set the virtual cursor position
   virtual_cursors.edit_with_cursor(function(vc)
-    func(register, count1, motion_cmd)
+    func(register, count, motion_cmd)
     vc:save_cursor_position()
   end)
 
@@ -170,9 +170,9 @@ end
 
 local function custom_function_with_char(func)
 
-  -- Save register and count1 because they may be lost
+  -- Save register and count because they may be lost
   local register = vim.v.register
-  local count1 = vim.v.count1
+  local count = vim.v.count
 
   -- Get a printable character
   local char = input.get_char()
@@ -182,11 +182,11 @@ local function custom_function_with_char(func)
   end
 
   -- Call func for the real cursor
-  func(register, count1, char)
+  func(register, count, char)
 
   -- Call func for each virtual cursor and set the virtual cursor position
   virtual_cursors.edit_with_cursor(function(vc)
-    func(register, count1, char)
+    func(register, count, char)
     vc:save_cursor_position()
   end)
 
@@ -194,9 +194,9 @@ end
 
 local function custom_function_with_motion_then_char(func)
 
-  -- Save register and count1 because they may be lost
+  -- Save register and count because they may be lost
   local register = vim.v.register
-  local count1 = vim.v.count1
+  local count = vim.v.count
 
   -- Get a motion command
   local motion_cmd = input.get_motion_cmd()
@@ -213,11 +213,11 @@ local function custom_function_with_motion_then_char(func)
   end
 
   -- Call func for the real cursor
-  func(register, count1, motion_cmd, char)
+  func(register, count, motion_cmd, char)
 
   -- Call func for each virtual cursor and set the virtual cursor position
   virtual_cursors.edit_with_cursor(function(vc)
-    func(register, count1, motion_cmd, char)
+    func(register, count, motion_cmd, char)
     vc:save_cursor_position()
   end)
 

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -149,7 +149,7 @@ function M.visit_all(func)
     vim.wo.ve = "onemore"
   end
 
-  for _, vc in ipairs(virtual_cursors) do
+  for idx, vc in ipairs(virtual_cursors) do
 
     if vc.within_buffer then
       -- Set virtual cursor position from extmark in case there were any changes


### PR DESCRIPTION
- Fix a missing idx that broke split pasting
- Use count rather than count1 for custom key maps
- Add an example for the stay-in-place plugin
- Add NoMatchParen/DoMatchParen to pre/post hook examples