### PR TITLE
Feat add jump next match

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ The plugin doesn't initially bind any keys, but creates three commands:
 | `MultipleCursorsAddDown` | Add a new virtual cursor, then move the real cursor down |
 | `MultipleCursorsAddUp` | Add a new virtual cursor, then move the real cursor up |
 | `MultipleCursorsMouseAddDelete` | Add a new virtual cursor to the mouse click position, unless there is already a virtual cursor at the mouse click position, in which case it is removed |
-| `MultipleCursorsAddBySearch` | Search for the word under the cursor (in normal mode) or the visual area (in visual mode) and add cursors to each match |
-| `MultipleCursorsAddBySearchV` | As above, but limit matches to the previous visual area |
+| `MultipleCursorsAddMatches` | Search for the word under the cursor (in normal mode) or the visual area (in visual mode) and add cursors to each match (by default this is limited to the visible buffer) |
+| `MultipleCursorsAddMatchesV` | As above, but limit matches to the previous visual area |
+| `MultipleCursorsAddJumpNextMatch` | Add a virtual cursor to the word under the cursor (in normal mode) or the visual area (in visual mode), then move the real cursor to the next match |
+| `MultipleCursorsJumpNextMatch` | Move the real cursor to the next match of the word under the cursor, or if `MultipleCursorsAddJumpNextMatch` was previously called in visual mode, the previously used visual area |
 
 These commands can be bound to keys, e.g.:
 ```lua
@@ -45,8 +47,10 @@ keys = {
   {"<C-Up>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "i"}},
   {"<C-k>", "<Cmd>MultipleCursorsAddUp<CR>"},
   {"<C-LeftMouse>", "<Cmd>MultipleCursorsMouseAddDelete<CR>", mode = {"n", "i"}},
-  {"<Leader>a", "<Cmd>MultipleCursorsAddBySearch<CR>", mode = {"n", "x"}},
-  {"<Leader>A", "<Cmd>MultipleCursorsAddBySearchV<CR>", mode = {"n", "x"}},
+  {"<Leader>a", "<Cmd>MultipleCursorsAddMatches<CR>", mode = {"n", "x"}},
+  {"<Leader>A", "<Cmd>MultipleCursorsAddMatchesV<CR>", mode = {"n", "x"}},
+  {"<Leader>d", "<Cmd>MultipleCursorsAddJumpNextMatch<CR>", mode = {"n", "x"}},
+  {"<Leader>D", "<Cmd>MultipleCursorsJumpNextMatch<CR>"},
 },
 ```
 
@@ -57,8 +61,10 @@ This configures the plugin with the default options, and sets the following key 
 - `Ctrl+Up` in normal and insert modes: `MultipleCursorsAddUp`
 - `Ctrl+k` in normal mode: `MultipleCursorsAddUp`
 - `Ctrl+LeftClick` in normal and insert modes: `MultipleCursorsMouseAddDelete`
-- `Leader+a` in normal and visual modes: `MultipleCursorsAddBySearch` (note: `<Leader>` must have been set previously)
-- `Leader+A` in normal and visual modes: `MultipleCursorsAddBySearchV`
+- `Leader+a` in normal and visual modes: `MultipleCursorsAddMatches` (note: `<Leader>` must have been set previously)
+- `Leader+A` in normal and visual modes: `MultipleCursorsAddMatchesV`
+- `Leader+d` in normal and visual modes: `MultipleCursorsAddJumpNextMatch`
+- `Leader+D` in normal mode: `MultipleCursorsJumpNextMatch`
 
 ## Usage
 

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -420,7 +420,7 @@ function M.add_cursors_by_search() _add_cursors_by_search(false) end
 function M.add_cursors_by_search_v() _add_cursors_by_search(true) end
 
 -- Add cursors by searching for the word under the cursor or visual area
-function M.add_cursor_by_search()
+function M.add_cursor_to_next_match()
 
   local pattern = nil
 
@@ -526,7 +526,7 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("MultipleCursorsMouseAddDelete", M.mouse_add_delete_cursor, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddBySearch", M.add_cursors_by_search, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddBySearchV", M.add_cursors_by_search_v, {})
-  vim.api.nvim_create_user_command("MultipleCursorsAddBySearchOne", M.add_cursor_by_search, {})
+  vim.api.nvim_create_user_command("MultipleCursorsAddToNextMatch", M.add_cursor_to_next_match, {})
 
 end
 

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -419,6 +419,67 @@ function M.add_cursors_by_search() _add_cursors_by_search(false) end
 -- previous visual area
 function M.add_cursors_by_search_v() _add_cursors_by_search(true) end
 
+-- Add cursors by searching for the word under the cursor or visual area
+function M.add_cursor_by_search()
+
+  local pattern = nil
+
+  if common.is_mode("v") then
+    pattern = get_visual_area_text()
+  else
+    -- Use the word under the cursor
+    pattern = vim.fn.expand("<cword>")
+  end
+
+  -- No pattern
+  if not pattern or pattern == "" then
+    return
+  end
+
+  -- Find matches (without the one for the cursor) and move the cursor to its match
+  local matches = search.get_matches_and_move_cursor(pattern, false)
+
+  if matches == nil then
+    return
+  end
+
+  -- Exit visual mode
+  -- Need to keep visual mode to keep searching for highlighted pattern
+  -- Otherwise word under cursor gets searched
+  
+  -- if common.is_mode("v") then
+  --   vim.cmd("normal!:")
+  -- end
+
+  -- Initialise if not already initialised
+  M.init()
+
+  -- Create a virtual cursor at every match
+  local cursor_pos = vim.fn.getcurpos()
+  local virtual_cursor_count = virtual_cursors.get_num_virtual_cursors()
+
+  local next_index = nil
+  for index, match in ipairs(matches) do
+  end
+  for index, match in ipairs(matches) do
+	-- Find the first instance of match after current cursor
+	if (match[1] == cursor_pos[2] and match[2] > cursor_pos[3]) or (match[1] > cursor_pos[2]) then
+	  next_index = index
+	  break
+	end
+  end
+  -- Loop around if current cursor is at last occurrence
+  if next_index == nil then
+    next_index = 1
+  end
+  next_index = next_index + virtual_cursor_count
+  -- Loop around if index is longer than number of matches
+  if next_index > #matches then
+    next_index = next_index - #matches
+  end
+  virtual_cursors.add(matches[next_index][1], matches[next_index][2], matches[next_index][2])
+end
+
 -- Add a new cursor at given position
 function M.add_cursor(lnum, col, curswant)
 
@@ -465,6 +526,7 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("MultipleCursorsMouseAddDelete", M.mouse_add_delete_cursor, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddBySearch", M.add_cursors_by_search, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddBySearchV", M.add_cursors_by_search_v, {})
+  vim.api.nvim_create_user_command("MultipleCursorsAddBySearchOne", M.add_cursor_by_search, {})
 
 end
 

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -407,7 +407,7 @@ local function get_search_pattern(use_saved_pattern)
 end
 
 -- Add cursors by searching for the word under the cursor or visual area
-local function _add_cursors_by_search(use_prev_visual_area)
+local function _add_cursors_to_matches(use_prev_visual_area)
 
   -- Get the search pattern: either the cursor under the word in normal mode or the visual area in
   -- visual mode
@@ -441,12 +441,11 @@ local function _add_cursors_by_search(use_prev_visual_area)
 
 end
 
--- Add cursors to each match of the word under the real cursor
-function M.add_cursors_by_search() _add_cursors_by_search(false) end
+-- Add cursors to each match of cword or visual area
+function M.add_cursors_to_matches() _add_cursors_to_matches(false) end
 
--- Add cursors to each match of the word under the real cursor, only within the
--- previous visual area
-function M.add_cursors_by_search_v() _add_cursors_by_search(true) end
+-- Add cursors to each match of cword or visual area, but only within the previous visual area
+function M.add_cursors_to_matches_v() _add_cursors_to_matches(true) end
 
 -- Add cursors by searching for the word under the cursor or visual area
 function M.add_cursor_to_next_match()
@@ -529,10 +528,11 @@ function M.setup(opts)
 
   vim.api.nvim_create_user_command("MultipleCursorsAddDown", M.add_cursor_down, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddUp", M.add_cursor_up, {})
+
   vim.api.nvim_create_user_command("MultipleCursorsMouseAddDelete", M.mouse_add_delete_cursor, {})
-  vim.api.nvim_create_user_command("MultipleCursorsAddBySearch", M.add_cursors_by_search, {})
-  vim.api.nvim_create_user_command("MultipleCursorsAddBySearchV", M.add_cursors_by_search_v, {})
-  vim.api.nvim_create_user_command("MultipleCursorsAddNextMatch", M.add_cursor_to_next_match, {})
+
+  vim.api.nvim_create_user_command("MultipleCursorsAddMatches", M.add_cursors_to_matches, {})
+  vim.api.nvim_create_user_command("MultipleCursorsAddMatchesV", M.add_cursors_to_matches_v, {})
 
 end
 

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -520,7 +520,7 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("MultipleCursorsMouseAddDelete", M.mouse_add_delete_cursor, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddBySearch", M.add_cursors_by_search, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddBySearchV", M.add_cursors_by_search_v, {})
-  vim.api.nvim_create_user_command("MultipleCursorsAddToNextMatch", M.add_cursor_to_next_match, {})
+  vim.api.nvim_create_user_command("MultipleCursorsAddNextMatch", M.add_cursor_to_next_match, {})
 
 end
 

--- a/lua/multiple-cursors/search.lua
+++ b/lua/multiple-cursors/search.lua
@@ -88,7 +88,7 @@ function M.get_matches_and_move_cursor(word, limit_to_visible, limit_to_prev_vis
 
   local limit = 0 -- whole buffer
 
-  if limit_to_prev_visible_area then
+  if limit_to_prev_visual_area then
     limit = 2
   elseif limit_to_visible then
     limit = 1

--- a/lua/multiple-cursors/search.lua
+++ b/lua/multiple-cursors/search.lua
@@ -174,4 +174,31 @@ function M.get_matches_and_move_cursor(word, limit_to_visible, limit_to_prev_vis
 
 end
 
+-- Get a single match after the cursor, optionally moving the cursor to the match before the cursor
+function M.get_next_match(word, move_cursor)
+
+  local ignorecase = vim.o.ignorecase
+  vim.o.ignorecase = false
+
+  -- Get the next match without moving the cursor
+  local match = vim.fn.searchpos(word, "nw")
+
+  if match[1] == 0 or match[2] == 0 then
+    vim.o.ignorecase = ignorecase
+    return nil
+  end
+
+  if move_cursor then
+    -- Move cursor to the previous match
+    vim.fn.searchpos(word, "bc")
+  end
+
+  vim.o.ignorecase = ignorecase
+
+  virtual_cursors.set_ignore_cursor_movement(false)
+
+  return match
+
+end
+
 return M

--- a/lua/multiple-cursors/search.lua
+++ b/lua/multiple-cursors/search.lua
@@ -109,6 +109,9 @@ function M.get_matches_and_move_cursor(word, limit_to_visible, limit_to_prev_vis
   local first = true
   local visible_end_lnum = vim.fn.line("w$")
 
+  local ignorecase = vim.o.ignorecase
+  vim.o.ignorecase = false
+
   while true do
     local match  = {0, 0}
 
@@ -131,6 +134,8 @@ function M.get_matches_and_move_cursor(word, limit_to_visible, limit_to_prev_vis
     -- Add the match
     table.insert(matches, match)
   end
+
+  vim.o.ignorecase = ignorecase
 
   -- If there is one or no matches
   if #matches <= 1 then


### PR DESCRIPTION
Adds two commands:

- `MultipleCursorsAddJumpNextMatch`: Add a cursor and jump to next match of word under cursor
- `MultipleCursorsJumpNextMatch`: Jump to next match

Also renames the two previous search commands:

- `MultipleCursorsAddBySearch` -> `MultipleCursorsAddMatches`: Add cursors to matches of word under cursor
- `MultipleCursorsAddBySearchV` -> `MultipleCursorsAddMatchesV`: As above but only within previous visual area

Also search commands are now case sensitive