### PR TITLE
Restore cursor position on exit

### DIFF
--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -253,6 +253,14 @@ function M.deinit(clear_virtual_cursors)
   if initialised then
 
     if clear_virtual_cursors then
+
+      -- Restore cursor to the position of the first virtual cursor
+      local pos = virtual_cursors.get_first_pos()
+
+      if pos then
+        vim.fn.cursor({pos[1], pos[2], 0, pos[3]})
+      end
+
       virtual_cursors.clear()
       bufnr = nil
       saved_pattern = nil
@@ -308,7 +316,7 @@ local function add_virtual_cursor_at_real_cursor(down)
     for i = 1, count1 do
       -- Add virtual cursor at the real cursor position
       local pos = vim.fn.getcurpos()
-      virtual_cursors.add(pos[2], pos[3], pos[5])
+      virtual_cursors.add(pos[2], pos[3], pos[5], true)
 
       -- Move the real cursor
       if down then
@@ -322,7 +330,7 @@ local function add_virtual_cursor_at_real_cursor(down)
 
     -- Add one virtual cursor at the real cursor position
     local pos = vim.fn.getcurpos()
-    virtual_cursors.add(pos[2], pos[3], pos[5])
+    virtual_cursors.add(pos[2], pos[3], pos[5], true)
 
     -- Move the real cursor
     if down then
@@ -352,7 +360,7 @@ function M.mouse_add_delete_cursor()
   local mouse_pos = vim.fn.getmousepos()
 
   -- Add a virtual cursor to the mouse click position, or delete an existing one
-  virtual_cursors.add_or_delete(mouse_pos.line, mouse_pos.column)
+  virtual_cursors.add_or_delete(mouse_pos.line, mouse_pos.column, false)
 
   if virtual_cursors.get_num_virtual_cursors() == 0 then
     M.deinit(true) -- Deinitialise if there are no more cursors
@@ -457,7 +465,7 @@ local function _add_cursors_to_matches(use_prev_visual_area)
 
   -- Create a virtual cursor at every match
   for _, match in ipairs(matches) do
-    virtual_cursors.add(match[1], match[2], match[2])
+    virtual_cursors.add(match[1], match[2], match[2], false)
   end
 
   vim.print(#matches .. " cursors added")
@@ -494,7 +502,7 @@ function M.add_cursor_and_jump_to_next_match()
 
   -- Add virtual cursor to cursor position
   local pos = vim.fn.getcurpos()
-  virtual_cursors.add(pos[2], pos[3], pos[5])
+  virtual_cursors.add(pos[2], pos[3], pos[5], true)
 
   -- Move cursor to match
   vim.fn.cursor({match[1], match[2], 0, match[2]})
@@ -526,7 +534,7 @@ function M.add_cursor(lnum, col, curswant)
   M.init()
 
   -- Add a virtual cursor
-  virtual_cursors.add(lnum, col, curswant)
+  virtual_cursors.add(lnum, col, curswant, false)
 
 end
 

--- a/lua/multiple-cursors/virtual_cursor.lua
+++ b/lua/multiple-cursors/virtual_cursor.lua
@@ -1,11 +1,13 @@
 local VirtualCursor = {}
 
-function VirtualCursor.new(lnum, col, curswant)
+function VirtualCursor.new(lnum, col, curswant, first)
   local self = setmetatable({}, VirtualCursor)
 
   self.lnum = lnum
   self.col = col
   self.curswant = curswant
+
+  self.first = first                    -- Is this the first cursor added?
 
   self.visual_start_lnum = 0            -- lnum for the start of the visual area
   self.visual_start_col = 0             -- col for the start of the visual area

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -52,7 +52,9 @@ function M.sort()
 end
 
 -- Add a new virtual cursor
-function M.add(lnum, col, curswant)
+-- set_first indicates that the first field should be set to true if this is the first virtual cursor
+-- On exit the cursor position will be set to the virtual cursor which has first = true
+function M.add(lnum, col, curswant, set_first)
 
   -- Check for existing virtual cursor
   for _, vc in ipairs(virtual_cursors) do
@@ -61,7 +63,9 @@ function M.add(lnum, col, curswant)
     end
   end
 
-  table.insert(virtual_cursors, VirtualCursor.new(lnum, col, curswant))
+  local first = set_first and #virtual_cursors == 0
+
+  table.insert(virtual_cursors, VirtualCursor.new(lnum, col, curswant, first))
 
   -- Create an extmark
   extmarks.update_virtual_cursor_extmarks(virtual_cursors[#virtual_cursors])
@@ -85,6 +89,19 @@ function M.add_or_delete(lnum, col)
   else
     M.add(lnum, col, col)
   end
+end
+
+-- Get the position of the virtual cursor with first = true
+function M.get_first_pos()
+
+  for _, vc in ipairs(virtual_cursors) do
+    if vc.first == true then
+      return {vc.lnum, vc.col, vc.curswant}
+    end
+  end
+
+  return nil
+
 end
 
 -- Clear all virtual cursors


### PR DESCRIPTION
When exiting multiple cursors, the cursor is restored to the position of the first added cursor, if that cursor was added with the `AddUp`, `AddDown`, or `AddJumpNextMatch` commands