### PR TITLE
Add real cursor movement commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The plugin doesn't initially bind any keys, but creates three commands:
 | `MultipleCursorsAddMatchesV` | As above, but limit matches to the previous visual area |
 | `MultipleCursorsAddJumpNextMatch` | Add a virtual cursor to the word under the cursor (in normal mode) or the visual area (in visual mode), then move the real cursor to the next match |
 | `MultipleCursorsJumpNextMatch` | Move the real cursor to the next match of the word under the cursor, or if `MultipleCursorsAddJumpNextMatch` was previously called in visual mode, the previously used visual area |
+| `MultipleCursorsMoveDown` | Move the real cursor down while leaving the virtual cursors where they are. |
+| `MultipleCursorsMoveUp` | Move the real cursor up while leaving the virtual cursors where they are. |
+| `MultipleCursorsMoveRight` | Move the real cursor right while leaving the virtual cursors where they are. |
+| `MultipleCursorsMoveLeft` | Move the real cursor left while leaving the virtual cursors where they are. |
 
 These commands can be bound to keys, e.g.:
 ```lua
@@ -51,6 +55,10 @@ keys = {
   {"<Leader>A", "<Cmd>MultipleCursorsAddMatchesV<CR>", mode = {"n", "x"}},
   {"<Leader>d", "<Cmd>MultipleCursorsAddJumpNextMatch<CR>", mode = {"n", "x"}},
   {"<Leader>D", "<Cmd>MultipleCursorsJumpNextMatch<CR>"},
+  {"<C-S-Down>", "<Cmd>MultipleCursorsMoveDown<CR>", mode = {"n", "i"}},
+  {"<C-S-Up>", "<Cmd>MultipleCursorsMoveUp<CR>", mode = {"n", "i"}},
+  {"<C-S-Right>", "<Cmd>MultipleCursorsMoveRight<CR>", mode = {"n", "i"}},
+  {"<C-S-Left>", "<Cmd>MultipleCursorsMoveLeft<CR>", mode = {"n", "i"}},
 },
 ```
 
@@ -65,6 +73,10 @@ This configures the plugin with the default options, and sets the following key 
 - `Leader+A` in normal and visual modes: `MultipleCursorsAddMatchesV`
 - `Leader+d` in normal and visual modes: `MultipleCursorsAddJumpNextMatch`
 - `Leader+D` in normal mode: `MultipleCursorsJumpNextMatch`
+- `Ctrl+Shift+Down` in normal and insert modes: `MultipleCursorsMoveDown`
+- `Ctrl+Shift+Up` in normal and insert modes: `MultipleCursorsMoveUp`
+- `Ctrl+Shift+Right` in normal and insert modes: `MultipleCursorsMoveRight`
+- `Ctrl+Shift+Left` in normal and insert modes: `MultipleCursorsMoveLeft`
 
 ## Usage
 
@@ -151,6 +163,10 @@ keys = {
   {"<C-Up>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "i"}},
   {"<C-k>", "<Cmd>MultipleCursorsAddUp<CR>"},
   {"<C-LeftMouse>", "<Cmd>MultipleCursorsMouseAddDelete<CR>", mode = {"n", "i"}},
+  {"<C-S-Down>", "<Cmd>MultipleCursorsMoveDown<CR>", mode = {"n", "i"}},
+  {"<C-S-Up>", "<Cmd>MultipleCursorsMoveUp<CR>", mode = {"n", "i"}},
+  {"<C-S-Right>", "<Cmd>MultipleCursorsMoveRight<CR>", mode = {"n", "i"}},
+  {"<C-S-Left>", "<Cmd>MultipleCursorsMoveLeft<CR>", mode = {"n", "i"}},
 },
 ```
 

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -343,6 +343,61 @@ local function add_virtual_cursor_at_real_cursor(down)
 
 end
 
+-- Move the real cursor while leaving the virtual ones where they are
+local function move_real_cursor(direction)
+
+  -- If normal mode
+  if common.is_mode("n") then
+
+    -- Move the real cursor
+    if direction == "down" then
+      vim.cmd("normal! j")
+    elseif direction == "up" then
+      vim.cmd("normal! k")
+    elseif direction == "right" then
+      vim.cmd("normal! l")
+    elseif direction == "left" then
+      vim.cmd("normal! h")
+    end
+
+  else -- Insert or replace mode
+
+    -- Move the real cursor
+    if direction == "down" then
+      common.feedkeys(nil, 0, "<Down>", nil)
+    elseif direction == "up" then
+      common.feedkeys(nil, 0, "<Up>", nil)
+    elseif direction == "right" then
+      common.feedkeys(nil, 0, "<Right>", nil)
+    elseif direction == "left" then
+      common.feedkeys(nil, 0, "<Left>", nil)
+    end
+
+  end
+
+end
+
+-- Move the real cursor up, while leaving the virtual cursors where they are
+function M.move_cursor_up()
+  return move_real_cursor("up")
+end
+
+-- Move the real cursor down, while leaving the virtual cursors where they are
+function M.move_cursor_down()
+  return move_real_cursor("down")
+end
+
+-- Move the real cursor right, while leaving the virtual cursors where they are
+function M.move_cursor_right()
+  return move_real_cursor("right")
+end
+
+-- Move the real cursor left, while leaving the virtual cursors where they are
+function M.move_cursor_left()
+  return move_real_cursor("left")
+end
+
+
 -- Add a virtual cursor at the real cursor position, then move the real cursor up
 function M.add_cursor_up()
   return add_virtual_cursor_at_real_cursor(false)
@@ -564,6 +619,11 @@ function M.setup(opts)
 
   -- Autocmds
   autocmd_group_id = vim.api.nvim_create_augroup("MultipleCursors", {})
+
+  vim.api.nvim_create_user_command("MultipleCursorsMoveDown", M.move_cursor_down, {})
+  vim.api.nvim_create_user_command("MultipleCursorsMoveUp", M.move_cursor_up, {})
+  vim.api.nvim_create_user_command("MultipleCursorsMoveRight", M.move_cursor_right, {})
+  vim.api.nvim_create_user_command("MultipleCursorsMoveLeft", M.move_cursor_left, {})
 
   vim.api.nvim_create_user_command("MultipleCursorsAddDown", M.add_cursor_down, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddUp", M.add_cursor_up, {})


### PR DESCRIPTION
The only thing I really missed about you plugin was being able to skip lines when adding new cursors. This PR adds commands to be able to move the real cursor while leaving the virtual ones where they are. This gives more flexibility to create cursors where needed. For example, you can create some cursors downward and when you hit an empty line, move the real cursor where you want, and continue adding cursors.