### PR TITLE
Lock virtual cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The plugin doesn't initially bind any keys, but creates three commands:
 | `MultipleCursorsAddMatchesV` | As above, but limit matches to the previous visual area |
 | `MultipleCursorsAddJumpNextMatch` | Add a virtual cursor to the word under the cursor (in normal mode) or the visual area (in visual mode), then move the real cursor to the next match |
 | `MultipleCursorsJumpNextMatch` | Move the real cursor to the next match of the word under the cursor, or if `MultipleCursorsAddJumpNextMatch` was previously called in visual mode, the previously used visual area |
+| `MultipleCursorsLockToggle` | Lock/Unlock virtual cursors while allowing the real cursor to move freely. |
 
 These commands can be bound to keys, e.g.:
 ```lua
@@ -51,6 +52,7 @@ keys = {
   {"<Leader>A", "<Cmd>MultipleCursorsAddMatchesV<CR>", mode = {"n", "x"}},
   {"<Leader>d", "<Cmd>MultipleCursorsAddJumpNextMatch<CR>", mode = {"n", "x"}},
   {"<Leader>D", "<Cmd>MultipleCursorsJumpNextMatch<CR>"},
+  {"<C-l>", "<Cmd>MultipleCursorsLockToggle<CR>", mode = {"n", "i", "x"}},
 },
 ```
 
@@ -65,6 +67,7 @@ This configures the plugin with the default options, and sets the following key 
 - `Leader+A` in normal and visual modes: `MultipleCursorsAddMatchesV`
 - `Leader+d` in normal and visual modes: `MultipleCursorsAddJumpNextMatch`
 - `Leader+D` in normal mode: `MultipleCursorsJumpNextMatch`
+- `Ctrl+l` in normal, visual, and insert modes: `MultipleCursorsLockToggle`
 
 ## Usage
 
@@ -151,6 +154,7 @@ keys = {
   {"<C-Up>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "i"}},
   {"<C-k>", "<Cmd>MultipleCursorsAddUp<CR>"},
   {"<C-LeftMouse>", "<Cmd>MultipleCursorsMouseAddDelete<CR>", mode = {"n", "i"}},
+  {"<C-l>", "<Cmd>MultipleCursorsLockToggle<CR>", mode = {"n", "i", "x"}},
 },
 ```
 
@@ -357,3 +361,4 @@ where `lnum` is the line number of the new cursor, `col` is the column, and `cur
 - Cursors may not be positioned correctly when moving up or down over extended characters
 - When using the mouse to add a cursor to an extended character, the cursor may be added to the next character
 - Please use the [Issues](https://github.com/brenton-leighton/multiple-cursors.nvim/issues) page to report issues, and please include any relevant Neovim options
+

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The plugin doesn't initially bind any keys, but creates three commands:
 | `MultipleCursorsAddMatchesV` | As above, but limit matches to the previous visual area |
 | `MultipleCursorsAddJumpNextMatch` | Add a virtual cursor to the word under the cursor (in normal mode) or the visual area (in visual mode), then move the real cursor to the next match |
 | `MultipleCursorsJumpNextMatch` | Move the real cursor to the next match of the word under the cursor, or if `MultipleCursorsAddJumpNextMatch` was previously called in visual mode, the previously used visual area |
-| `MultipleCursorsLockToggle` | Lock/Unlock virtual cursors while allowing the real cursor to move freely. |
+| `MultipleCursorsLock` | Toggle locking or unlocking the virtual cursors to allow for moving (or editing at) only the real cursor |
 
 These commands can be bound to keys, e.g.:
 ```lua
@@ -52,7 +52,7 @@ keys = {
   {"<Leader>A", "<Cmd>MultipleCursorsAddMatchesV<CR>", mode = {"n", "x"}},
   {"<Leader>d", "<Cmd>MultipleCursorsAddJumpNextMatch<CR>", mode = {"n", "x"}},
   {"<Leader>D", "<Cmd>MultipleCursorsJumpNextMatch<CR>"},
-  {"<C-l>", "<Cmd>MultipleCursorsLockToggle<CR>", mode = {"n", "i", "x"}},
+  {"<Leader>l", "<Cmd>MultipleCursorsLockToggle<CR>", mode = {"n", "x"}},
 },
 ```
 
@@ -67,7 +67,7 @@ This configures the plugin with the default options, and sets the following key 
 - `Leader+A` in normal and visual modes: `MultipleCursorsAddMatchesV`
 - `Leader+d` in normal and visual modes: `MultipleCursorsAddJumpNextMatch`
 - `Leader+D` in normal mode: `MultipleCursorsJumpNextMatch`
-- `Ctrl+l` in normal, visual, and insert modes: `MultipleCursorsLockToggle`
+- `Leader+l` in normal and visual modes: `MultipleCursorsLock`
 
 ## Usage
 
@@ -154,7 +154,6 @@ keys = {
   {"<C-Up>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "i"}},
   {"<C-k>", "<Cmd>MultipleCursorsAddUp<CR>"},
   {"<C-LeftMouse>", "<Cmd>MultipleCursorsMouseAddDelete<CR>", mode = {"n", "i"}},
-  {"<C-l>", "<Cmd>MultipleCursorsLockToggle<CR>", mode = {"n", "i", "x"}},
 },
 ```
 
@@ -361,4 +360,3 @@ where `lnum` is the line number of the new cursor, `col` is the column, and `cur
 - Cursors may not be positioned correctly when moving up or down over extended characters
 - When using the mouse to add a cursor to an extended character, the cursor may be added to the next character
 - Please use the [Issues](https://github.com/brenton-leighton/multiple-cursors.nvim/issues) page to report issues, and please include any relevant Neovim options
-

--- a/README.md
+++ b/README.md
@@ -359,4 +359,5 @@ where `lnum` is the line number of the new cursor, `col` is the column, and `cur
 - In insert or replace mode, anything to do with tabs may not behave correctly, in particular if you are using less common options
 - Cursors may not be positioned correctly when moving up or down over extended characters
 - When using the mouse to add a cursor to an extended character, the cursor may be added to the next character
+- When virtual cursors are locked, switching to or from visual mode won't update the virtual cursors and should be avoided
 - Please use the [Issues](https://github.com/brenton-leighton/multiple-cursors.nvim/issues) page to report issues, and please include any relevant Neovim options

--- a/lua/multiple-cursors/extmarks.lua
+++ b/lua/multiple-cursors/extmarks.lua
@@ -311,12 +311,8 @@ end
 
 -- Update all extmarks for a virtual cursor
 function M.update_virtual_cursor_extmarks(vc)
-  if vc.within_buffer then
-    update_virtual_cursor_extmark(vc)
-    update_virtual_cursor_visual_extmarks(vc)
-  else -- Cursor not within buffer
-    M.delete_virtual_cursor_extmarks(vc)
-  end
+  update_virtual_cursor_extmark(vc)
+  update_virtual_cursor_visual_extmarks(vc)
 end
 
 -- Set virtual cursor position from its extmark

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -343,10 +343,6 @@ local function add_virtual_cursor_at_real_cursor(down)
 
 end
 
-function M.virtual_cursors_lock_toggle()
-  virtual_cursors.lock_toggle()
-end
-
 -- Add a virtual cursor at the real cursor position, then move the real cursor up
 function M.add_cursor_up()
   return add_virtual_cursor_at_real_cursor(false)
@@ -542,6 +538,13 @@ function M.add_cursor(lnum, col, curswant)
 
 end
 
+-- Toggle locking the virtual cursors if initialised
+function M.lock()
+  if initialised then
+    virtual_cursors.toggle_lock()
+  end
+end
+
 function M.setup(opts)
 
   -- Options
@@ -569,7 +572,6 @@ function M.setup(opts)
   -- Autocmds
   autocmd_group_id = vim.api.nvim_create_augroup("MultipleCursors", {})
 
-  vim.api.nvim_create_user_command("MultipleCursorsLockToggle", M.virtual_cursors_lock_toggle, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddDown", M.add_cursor_down, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddUp", M.add_cursor_up, {})
 
@@ -581,6 +583,7 @@ function M.setup(opts)
   vim.api.nvim_create_user_command("MultipleCursorsAddJumpNextMatch", M.add_cursor_and_jump_to_next_match, {})
   vim.api.nvim_create_user_command("MultipleCursorsJumpNextMatch", M.jump_to_next_match, {})
 
+  vim.api.nvim_create_user_command("MultipleCursorsLock", M.lock, {})
 end
 
 return M

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -343,6 +343,10 @@ local function add_virtual_cursor_at_real_cursor(down)
 
 end
 
+function M.virtual_cursors_lock_toggle()
+  virtual_cursors.lock_toggle()
+end
+
 -- Add a virtual cursor at the real cursor position, then move the real cursor up
 function M.add_cursor_up()
   return add_virtual_cursor_at_real_cursor(false)
@@ -565,6 +569,7 @@ function M.setup(opts)
   -- Autocmds
   autocmd_group_id = vim.api.nvim_create_augroup("MultipleCursors", {})
 
+  vim.api.nvim_create_user_command("MultipleCursorsLockToggle", M.virtual_cursors_lock_toggle, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddDown", M.add_cursor_down, {})
   vim.api.nvim_create_user_command("MultipleCursorsAddUp", M.add_cursor_up, {})
 

--- a/lua/multiple-cursors/move_special.lua
+++ b/lua/multiple-cursors/move_special.lua
@@ -34,7 +34,7 @@ end
 -- Normal mode backspace command for all virtual cursors
 local function all_virtual_cursors_normal_backspace(count)
   count = vim.fn.max({count, 1})
-  virtual_cursors.visit_in_buffer(function(vc) virtual_cursor_normal_backspace(vc, count) end)
+  virtual_cursors.visit_all(function(vc) virtual_cursor_normal_backspace(vc, count) end)
 end
 
 -- Normal mode backspace command

--- a/lua/multiple-cursors/normal_mode_change.lua
+++ b/lua/multiple-cursors/normal_mode_change.lua
@@ -26,7 +26,7 @@ end
 
 local function _i()
   -- curswant is lost
-  virtual_cursors.visit_in_buffer(function(vc)
+  virtual_cursors.visit_all(function(vc)
     vc.curswant = vc.col
   end)
 end
@@ -45,7 +45,7 @@ end
 local function _O()
 
   -- New line before current line
-  virtual_cursors.visit_in_buffer(function(vc)
+  virtual_cursors.visit_all(function(vc)
     if vc.lnum == 1 then -- First line, move to start of line
       vc.col = 1
       vc.curswant = 1
@@ -71,7 +71,7 @@ end
 
 local function _v()
 
-  virtual_cursors.visit_in_buffer(function(vc)
+  virtual_cursors.visit_all(function(vc)
 
     -- Save cursor position as visual area start
     vc.visual_start_lnum = vc.lnum

--- a/lua/multiple-cursors/virtual_cursor.lua
+++ b/lua/multiple-cursors/virtual_cursor.lua
@@ -17,7 +17,6 @@ function VirtualCursor.new(lnum, col, curswant, first)
   self.visual_multiline_mark_id = 0     -- ID of the visual area extmark then spans multiple lines
   self.visual_empty_line_mark_ids = {}  -- IDs of the visual area extmarks for empty lines
 
-  self.within_buffer = true             -- lnum is within the buffer
   self.editable = true                  -- To disable editing the virtual cursor when
                                         -- in collision with the real cursor
   self.delete = false                   -- To mark the virtual cursor for deletion

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -221,8 +221,16 @@ function M.visit_with_cursor(func)
 
 end
 
+function M.lock_toggle()
+  ignore_cursor_movement = not ignore_cursor_movement
+end
+
 -- Visit virtual cursors and execute a normal command to move them
 function M.move_with_normal_command(count, cmd)
+
+  if ignore_cursor_movement == true then
+    return
+  end
 
   M.visit_with_cursor(function(vc)
     common.normal_bang(nil, count, cmd, nil)

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -134,17 +134,15 @@ function M.cursor_moved()
   for idx = #virtual_cursors, 1, -1 do
     local vc = virtual_cursors[idx]
 
-    if vc.within_buffer then
-      -- First update the virtual cursor position from the extmark in case there
-      -- was a change due to editing
-      extmarks.update_virtual_cursor_position(vc)
+    -- First update the virtual cursor position from the extmark in case there
+    -- was a change due to editing
+    extmarks.update_virtual_cursor_position(vc)
 
-      -- Mark editable to false if coincident with the real cursor
-      vc.editable = not (vc.lnum == pos[2] and vc.col == pos[3])
+    -- Mark editable to false if coincident with the real cursor
+    vc.editable = not (vc.lnum == pos[2] and vc.col == pos[3])
 
-      -- Update the extmark (extmark is invisible if editable == false)
-      extmarks.update_virtual_cursor_extmarks(vc)
-    end
+    -- Update the extmark (extmark is invisible if editable == false)
+    extmarks.update_virtual_cursor_extmarks(vc)
   end
 end
 
@@ -168,10 +166,8 @@ function M.visit_all(func)
 
   for idx, vc in ipairs(virtual_cursors) do
 
-    if vc.within_buffer then
-      -- Set virtual cursor position from extmark in case there were any changes
-      extmarks.update_virtual_cursor_position(vc)
-    end
+    -- Set virtual cursor position from extmark in case there were any changes
+    extmarks.update_virtual_cursor_position(vc)
 
     if not vc.delete then
       -- Call the function
@@ -196,23 +192,12 @@ function M.visit_all(func)
 
 end
 
--- Visit virtual cursors within buffer
-function M.visit_in_buffer(func)
-
-  M.visit_all(function(vc, idx)
-    if vc.within_buffer then
-      func(vc, idx)
-    end
-  end)
-
-end
-
 -- Visit virtual cursors within the buffer with the real cursor
 function M.visit_with_cursor(func)
 
   ignore_cursor_movement = true
 
-  M.visit_in_buffer(function(vc, idx)
+  M.visit_all(function(vc, idx)
     vc:set_cursor_position()
     func(vc, idx)
   end)
@@ -254,7 +239,7 @@ function M.edit(func)
   ignore_cursor_movement = true
   extmarks.save_cursor()
 
-  M.visit_in_buffer(function(vc, idx)
+  M.visit_all(function(vc, idx)
     if vc.editable then
       func(vc, idx)
     end
@@ -361,7 +346,7 @@ function M.visual_mode(func)
   -- Save the visual area to extmarks
   extmarks.save_visual_area()
 
-  M.visit_in_buffer(function(vc, idx)
+  M.visit_all(function(vc, idx)
     -- Set visual area
     vc:set_visual_area()
 
@@ -408,7 +393,7 @@ function M.can_split_paste(num_lines)
   local count = 0
 
   for _, vc in ipairs(virtual_cursors) do
-    if vc.within_buffer and vc.editable then
+    if vc.editable then
       count = count + 1
     end
   end

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -11,6 +11,9 @@ local virtual_cursors = {}
 -- Set to true when the cursor is being moved to suppress M.cursor_moved()
 local ignore_cursor_movement = false
 
+-- For locking the virtual cursors
+local locked = false
+
 -- Remove any virtual cursors marked for deletion
 local function clean_up()
   for idx = #virtual_cursors, 1, -1 do
@@ -107,6 +110,7 @@ end
 -- Clear all virtual cursors
 function M.clear()
   virtual_cursors = {}
+  locked = false
 end
 
 function M.update_extmarks()
@@ -146,11 +150,19 @@ function M.cursor_moved()
   end
 end
 
+function M.toggle_lock()
+  locked = not locked
+end
+
 
 -- Visitors --------------------------------------------------------------------
 
 -- Visit all virtual cursors
 function M.visit_all(func)
+
+  if locked then
+    return
+  end
 
   -- Save cursor position
   -- This is because changing virtualedit causes curswant to be reset
@@ -206,16 +218,8 @@ function M.visit_with_cursor(func)
 
 end
 
-function M.lock_toggle()
-  ignore_cursor_movement = not ignore_cursor_movement
-end
-
 -- Visit virtual cursors and execute a normal command to move them
 function M.move_with_normal_command(count, cmd)
-
-  if ignore_cursor_movement == true then
-    return
-  end
 
   M.visit_with_cursor(function(vc)
     common.normal_bang(nil, count, cmd, nil)

--- a/lua/multiple-cursors/visual_mode.lua
+++ b/lua/multiple-cursors/visual_mode.lua
@@ -6,7 +6,7 @@ local input = require("multiple-cursors.input")
 
 -- Escape command
 function M.escape()
-  virtual_cursors.visit_in_buffer(function(vc)
+  virtual_cursors.visit_all(function(vc)
     -- Move cursor back if it's at the end of a non empty line
     vc.col = vim.fn.min({vc.col, common.get_max_col(vc.lnum) - 1})
     vc.col = vim.fn.max({vc.col, 1})


### PR DESCRIPTION
Adds the `MultipleCursorsLock` command to toggle locking the virtual cursors and allowing only movement/editing of the real cursor