### PR TITLE
Maintain visual area when adding cursors in visual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ For [lazy.nvim](https://github.com/folke/lazy.nvim), add a section to the plugin
 
 This creates a number of key mappings:
 
-- `Ctrl+j` in normal mode or `Ctrl+Down` in normal and insert modes: Add a new cursor then move the real cursor down
-- `Ctrl+k` in normal mode or `Ctrl+Up` in normal and insert modes: Add a new cursor then move the real cursor up
-- `Ctrl+LeftClick` in normal and insert modes: Add a new cursor (or remove an existing cursor) at the clicked position
-- `Leader+a` in normal and visual modes: Add new cursors to matches to the pattern under the cursor
+- `Ctrl+j` and `Ctrl+Down`: Add a new cursor then move the real cursor down
+- `Ctrl+k` and `Ctrl+Up`: Add a new cursor then move the real cursor up
+- `Ctrl+LeftClick`: Add a new cursor (or remove an existing cursor) at the clicked position
+- `Leader+a`: Add new cursors to matches to the pattern under the cursor
 
 After cursors have been added, Neovim can be used mostly as normal.
 See [Supported commands](#Supported-commands) for more information.
@@ -50,13 +50,13 @@ The plugin creates a number of user commands:
 
 | Command | Description |
 | --- | --- |
-| `MultipleCursorsAddDown` | Add a new virtual cursor, then move the real cursor down. In normal mode multiple new virtual cursors can be added with a `count`. |
-| `MultipleCursorsAddUp` | Add a new virtual cursor, then move the real cursor up. In normal mode multiple new virtual cursors can be added with a `count`. |
+| `MultipleCursorsAddDown` | Add a new virtual cursor, then move the real cursor down. </br> In normal or visual modes multiple new virtual cursors can be added with a `count`. |
+| `MultipleCursorsAddUp` | Add a new virtual cursor, then move the real cursor up. </br> In normal or visual modes multiple new virtual cursors can be added with a `count`. |
 | `MultipleCursorsMouseAddDelete` | Add a new virtual cursor to the mouse click position, or remove an existing cursor |
 | `MultipleCursorsAddMatches` | Search for the word under the cursor (in normal mode) or the visual area (in visual mode) and add a new cursor to each match. By default cursors are only added to matches in the visible buffer. |
 | `MultipleCursorsAddMatchesV` | As above, but limit matches to the previous visual area |
 | `MultipleCursorsAddJumpNextMatch` | Add a virtual cursor to the word under the cursor (in normal mode) or the visual area (in visual mode), then move the real cursor to the next match |
-| `MultipleCursorsJumpNextMatch` | Move the real cursor to the next match of the word under the cursor. If `MultipleCursorsAddJumpNextMatch` was previously called in visual mode, the real cursor is moved to the next match of the previously used visual area. |
+| `MultipleCursorsJumpNextMatch` | Move the real cursor to the next match of the word under the cursor. </br> If `MultipleCursorsAddJumpNextMatch` was previously called in visual mode, the real cursor is moved to the next match of the previously used visual area. |
 | `MultipleCursorsLock` | Toggle locking the virtual cursors |
 
 The additional commands can be mapped by adding them to the `keys` table, e.g.:
@@ -322,14 +322,12 @@ Automatically inserts and deletes paired characters.
 The plugin needs to be disabled while using multiple cursors:
 
 ```lua
-opts = {
-  pre_hook = function()
-    vim.g.minipairs_disable = true
-  end,
-  post_hook = function()
-    vim.g.minipairs_disable = false
-  end,
-},
+pre_hook = function()
+  vim.g.minipairs_disable = true
+end,
+post_hook = function()
+  vim.g.minipairs_disable = false
+end,
 ```
 
 #### [mini.surround](https://github.com/echasnovski/mini.surround) and [nvim-surround](https://github.com/kylechui/nvim-surround)
@@ -340,12 +338,10 @@ The issue with both of these plugins is that they don't have functions that can 
 One workaround would be to use a different key sequence to execute the command while using multiple cursors, e.g. for mini.surround `sa` command:
 
 ```lua
-opts = {
-  custom_key_maps = {
-    {"n", "<Leader>sa", function(_, count, motion_cmd, char)
-      vim.cmd("normal " .. count .. "sa" .. motion_cmd .. char)
-    end, "mc"},
-  },
+custom_key_maps = {
+  {"n", "<Leader>sa", function(_, count, motion_cmd, char)
+    vim.cmd("normal " .. count .. "sa" .. motion_cmd .. char)
+  end, "mc"},
 },
 ```
 
@@ -357,14 +353,12 @@ Automatically inserts and deletes paired characters.
 The plugin needs to be disabled while using multiple cursors:
 
 ```lua
-opts = {
-  pre_hook = function()
-    require('nvim-autopairs').disable()
-  end,
-  post_hook = function()
-    require('nvim-autopairs').enable()
-  end,
-},
+pre_hook = function()
+  require('nvim-autopairs').disable()
+end,
+post_hook = function()
+  require('nvim-autopairs').enable()
+end,
 ```
 
 #### [nvim-spider](https://github.com/chrisgrieser/nvim-spider)
@@ -373,32 +367,30 @@ Improves `w`, `e`, and `b` motions.
 For normal mode `count` must be set before nvim-spider's motion function is called:
 
 ```lua
-opts = {
-  custom_key_maps = {
-    -- w
-    {{"n", "x"}, "w", function(_, count)
-      if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
-        vim.cmd("normal! " .. count)
-      end
-      require('spider').motion('w')
-    end},
+custom_key_maps = {
+  -- w
+  {{"n", "x"}, "w", function(_, count)
+    if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
+      vim.cmd("normal! " .. count)
+    end
+    require('spider').motion('w')
+  end},
 
-    -- e
-    {{"n", "x"}, "e", function(_, count)
-      if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
-        vim.cmd("normal! " .. count)
-      end
-      require('spider').motion('e')
-    end},
+  -- e
+  {{"n", "x"}, "e", function(_, count)
+    if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
+      vim.cmd("normal! " .. count)
+    end
+    require('spider').motion('e')
+  end},
 
-    -- b
-    {{"n", "x"}, "b", function(_, count)
-      if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
-        vim.cmd("normal! " .. count)
-      end
-      require('spider').motion('b')
-    end},
-  },
+  -- b
+  {{"n", "x"}, "b", function(_, count)
+    if  count ~=0 and vim.api.nvim_get_mode().mode == "n" then
+      vim.cmd("normal! " .. count)
+    end
+    require('spider').motion('b')
+  end},
 },
 ```
 
@@ -408,12 +400,10 @@ Maintains cursor position when indenting and unindenting.
 This plugin can be used with multiple cursors by adding key maps, e.g.
 
 ```lua
-opts = {
-  custom_key_maps = {
-    {"n", {">>", "<Tab>"}, function() require("stay-in-place").shift_right_line() end},
-    {"n", "<<", function() require("stay-in-place").shift_left_line() end},
-    {{"n", "i"}, "<S-Tab>", function() require("stay-in-place").shift_left_line() end},
-  },
+custom_key_maps = {
+  {"n", {">>", "<Tab>"}, function() require("stay-in-place").shift_right_line() end},
+  {"n", "<<", function() require("stay-in-place").shift_left_line() end},
+  {{"n", "i"}, "<S-Tab>", function() require("stay-in-place").shift_left_line() end},
 },
 ```
 
@@ -456,19 +446,17 @@ end,
 Alternatively, colours could be defined in the `pre_hook` function (which runs every time multiple cursors mode is entered):
 
 ```lua
-opts = {
-  pre_hook = function()
-    -- Set MultipleCursorsCursor to be slightly darker than Cursor
-    local cursor = vim.api.nvim_get_hl(0, {name="Cursor"})
-    cursor.bg = cursor.bg - 3355443  -- -#333333
-    vim.api.nvim_set_hl(0, "MultipleCursorsCursor", cursor)
+pre_hook = function()
+  -- Set MultipleCursorsCursor to be slightly darker than Cursor
+  local cursor = vim.api.nvim_get_hl(0, {name="Cursor"})
+  cursor.bg = cursor.bg - 3355443  -- -#333333
+  vim.api.nvim_set_hl(0, "MultipleCursorsCursor", cursor)
 
-    -- Set MultipleCursorsVisual to be slightly darker than Visual
-    local visual = vim.api.nvim_get_hl(0, {name="Visual"})
-    visual.bg = visual.bg - 1118481  -- -#111111
-    vim.api.nvim_set_hl(0, "MultipleCursorsVisual", visual)
-  end,
-}
+  -- Set MultipleCursorsVisual to be slightly darker than Visual
+  local visual = vim.api.nvim_get_hl(0, {name="Visual"})
+  visual.bg = visual.bg - 1118481  -- -#111111
+  vim.api.nvim_set_hl(0, "MultipleCursorsVisual", visual)
+end,
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ For [lazy.nvim](https://github.com/folke/lazy.nvim), add a section to the plugin
   version = "*",  -- Use the latest tagged version
   opts = {},  -- This causes the plugin setup function to be called
   keys = {
-    {"<C-j>", "<Cmd>MultipleCursorsAddDown<CR>"},
-    {"<C-Down>", "<Cmd>MultipleCursorsAddDown<CR>", mode = {"n", "i"}},
-    {"<C-k>", "<Cmd>MultipleCursorsAddUp<CR>"},
-    {"<C-Up>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "i"}},
+    {"<C-j>", "<Cmd>MultipleCursorsAddDown<CR>", mode = {"n", "x"}},
+    {"<C-Down>", "<Cmd>MultipleCursorsAddDown<CR>", mode = {"n", "i", "x"}},
+    {"<C-k>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "x"}},
+    {"<C-Up>", "<Cmd>MultipleCursorsAddUp<CR>", mode = {"n", "i", "x"}},
     {"<C-LeftMouse>", "<Cmd>MultipleCursorsMouseAddDelete<CR>", mode = {"n", "i"}},
     {"<Leader>a", "<Cmd>MultipleCursorsAddMatches<CR>", mode = {"n", "x"}},
   },

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The additional commands can be mapped by adding them to the `keys` table, e.g.:
 ```lua
 {"<Leader>A", "<Cmd>MultipleCursorsAddMatchesV<CR>", mode = {"n", "x"}},
 {"<Leader>d", "<Cmd>MultipleCursorsAddJumpNextMatch<CR>", mode = {"n", "x"}},
-{"<Leader>D", "<Cmd>MultipleCursorsJumpNextMatch<CR>"},
+{"<Leader>D", "<Cmd>MultipleCursorsJumpNextMatch<CR>", mode = {"n", "x"}},
 {"<Leader>l", "<Cmd>MultipleCursorsLockToggle<CR>", mode = {"n", "x"}},
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The plugin creates a number of user commands:
 | `MultipleCursorsAddMatches` | Search for the word under the cursor (in normal mode) or the visual area (in visual mode) and add a new cursor to each match. By default cursors are only added to matches in the visible buffer. |
 | `MultipleCursorsAddMatchesV` | As above, but limit matches to the previous visual area |
 | `MultipleCursorsAddJumpNextMatch` | Add a virtual cursor to the word under the cursor (in normal mode) or the visual area (in visual mode), then move the real cursor to the next match |
-| `MultipleCursorsJumpNextMatch` | Move the real cursor to the next match of the word under the cursor. </br> If `MultipleCursorsAddJumpNextMatch` was previously called in visual mode, the real cursor is moved to the next match of the previously used visual area. |
+| `MultipleCursorsJumpNextMatch` | Move the real cursor to the next match of the word under the cursor (in normal mode) or the visual area (in visual mode) |
 | `MultipleCursorsLock` | Toggle locking the virtual cursors |
 
 The additional commands can be mapped by adding them to the `keys` table, e.g.:

--- a/lua/multiple-cursors/common.lua
+++ b/lua/multiple-cursors/common.lua
@@ -116,4 +116,11 @@ function M.get_normalised_visual_area()
 
 end
 
+-- Set visual area marks and apply
+function M.set_visual_area(v_lnum, v_col, lnum, col)
+  vim.api.nvim_buf_set_mark(0, "<", v_lnum, v_col - 1, {})
+  vim.api.nvim_buf_set_mark(0, ">", lnum, col - 1, {})
+  vim.cmd("normal! gv")
+end
+
 return M

--- a/lua/multiple-cursors/common.lua
+++ b/lua/multiple-cursors/common.lua
@@ -88,11 +88,32 @@ function M.get_col(lnum, curswant)
 end
 
 -- Get current visual area
--- Returns {lnum1, col1, lnum2, col2}
+-- Returns v_lnum, v_col, lnum, col, curswant
 function M.get_visual_area()
-  local cursor_pos = vim.fn.getcurpos()
-  local visual_start_pos = vim.fn.getpos("v")
-  return {visual_start_pos[2], visual_start_pos[3], cursor_pos[2], cursor_pos[3]}
+  local vpos = vim.fn.getpos("v")
+  local cpos = vim.fn.getcurpos()
+  return vpos[2], vpos[3], cpos[2], cpos[3], cpos[5]
+end
+
+-- Get current visual area in a forward direction
+-- returns lnum1, col1, lnum2, col2
+function M.get_normalised_visual_area()
+
+  local v_lnum, v_col, lnum, col = M.get_visual_area()
+
+  -- Normalise
+  if v_lnum < lnum then
+    return v_lnum, v_col, lnum, col
+  elseif lnum < v_lnum then
+    return lnum, col, v_lnum, v_col
+  else -- v_lnum == lnum
+    if v_col <= col then
+      return v_lnum, v_col, lnum, col
+    else -- col < v_col
+      return lnum, col, v_lnum, v_col
+    end
+  end
+
 end
 
 return M

--- a/lua/multiple-cursors/extmarks.lua
+++ b/lua/multiple-cursors/extmarks.lua
@@ -247,25 +247,6 @@ local function delete_virtual_cursor_visual_extmarks(vc)
 
 end
 
--- Get the positions of the visual area in a forward direction
-local function get_normalised_visual_area(vc)
-  local lnum1 = vc.visual_start_lnum
-  local col1 = vc.visual_start_col
-  local lnum2 = vc.lnum
-  local col2 = vc.col
-
-  if not vc:is_visual_area_forward() then
-    lnum1 = vc.lnum
-    col1 = vc.col
-    lnum2 = vc.visual_start_lnum
-
-    -- If backwards, add 1 to the end column because the cursor isn't there
-    col2 = vim.fn.min({vc.visual_start_col + 1, common.get_max_col(lnum2)})
-  end
-
-  return lnum1, col1, lnum2, col2
-end
-
 -- Find any empty lines, and adjust lnum1 (and col1) to not start on an empty line
 -- Returns a new lnum1, new col1, and empty lines
 local function find_empty_lines_in_visual_area(lnum1, col1, lnum2, col2)
@@ -303,7 +284,7 @@ local function update_virtual_cursor_visual_extmarks(vc)
   vc.visual_start_mark_id = set_extmark(vc.visual_start_lnum, vc.visual_start_col, vc.visual_start_mark_id, "", 0)
 
   -- Get the positions of the visual area in a forward direction
-  local lnum1, col1, lnum2, col2 = get_normalised_visual_area(vc)
+  local lnum1, col1, lnum2, col2 = vc:get_normalised_visual_area(true)
 
   -- Find any empty lines, and adjust lnum1 (and col1) to not start on an empty line
   local lnum1, col1, empty_lines = find_empty_lines_in_visual_area(lnum1, col1, lnum2, col2)
@@ -386,10 +367,10 @@ end
 
 function M.save_visual_area()
 
-  local visual_area = common.get_visual_area()
+  local v_lnum, v_col, lnum, col = common.get_visual_area()
 
-  visual_area_start_mark_id = set_extmark(visual_area[1], visual_area[2], visual_area_start_mark_id, "", 0)
-  visual_area_end_mark_id = set_extmark(visual_area[3], visual_area[4], visual_area_end_mark_id, "", 0)
+  visual_area_start_mark_id = set_extmark(v_lnum, v_col, visual_area_start_mark_id, "", 0)
+  visual_area_end_mark_id = set_extmark(lnum, col, visual_area_end_mark_id, "", 0)
 
 end
 

--- a/lua/multiple-cursors/extmarks.lua
+++ b/lua/multiple-cursors/extmarks.lua
@@ -391,10 +391,7 @@ function M.restore_visual_area()
 
     -- If the extmark positions are valid
     if next(start_pos) ~= nil and next(end_pos) ~= nil then
-        vim.cmd("normal!:") -- Exit to normal mode
-        vim.api.nvim_buf_set_mark(0, "<", start_pos[1] + 1, start_pos[2], {})
-        vim.api.nvim_buf_set_mark(0, ">", end_pos[1] + 1, end_pos[2], {})
-        vim.cmd("normal! gv") -- Return to visual mode
+        common.set_visual_area(start_pos[1] + 1, start_pos[2] + 1, end_pos[1] + 1, end_pos[2] + 1)
     end
 
   end

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -257,8 +257,8 @@ function M.deinit(clear_virtual_cursors)
 
     if clear_virtual_cursors then
 
-      -- Restore cursor to the position of the first virtual cursor
-      local pos = virtual_cursors.get_first_pos()
+      -- Restore cursor to the position of the oldest virtual cursor
+      local pos = virtual_cursors.get_exit_pos()
 
       if pos then
         vim.fn.cursor({pos[1], pos[2], 0, pos[3]})
@@ -385,7 +385,7 @@ function M.mouse_add_delete_cursor()
   local mouse_pos = vim.fn.getmousepos()
 
   -- Add a virtual cursor to the mouse click position, or delete an existing one
-  virtual_cursors.add_or_delete(mouse_pos.line, mouse_pos.column, false)
+  virtual_cursors.add_or_delete(mouse_pos.line, mouse_pos.column)
 
   if virtual_cursors.get_num_virtual_cursors() == 0 then
     M.deinit(true) -- Deinitialise if there are no more cursors

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -370,34 +370,9 @@ function M.mouse_add_delete_cursor()
   end
 end
 
--- Get the current visual area normalised
-local function get_visual_area()
-  local v_lnum = vim.fn.line("v")
-  local v_col = vim.fn.col("v")
-  local c_lnum = vim.fn.line(".")
-  local c_col = vim.fn.col(".")
-
-  if v_lnum == 0 or v_col == 0  or c_lnum == 0 or c_col == 0 then
-    return nil
-  end
-
-  -- Normalise
-  if v_lnum < c_lnum then
-    return v_lnum, v_col, c_lnum, c_col
-  elseif c_lnum < v_lnum then
-    return c_lnum, c_col, v_lnum, v_col
-  else -- v_lnum == c_lnum
-    if v_col <= c_col then
-      return v_lnum, v_col, c_lnum, c_col
-    else -- c_col < v_col
-      return c_lnum, c_col, v_lnum, v_col
-    end
-  end
-end
-
 local function get_visual_area_text()
 
- local lnum1, col1, lnum2, col2 = get_visual_area()
+  local lnum1, col1, lnum2, col2 = common.get_normalised_visual_area()
 
   if lnum1 ~= lnum2 then
     vim.print("Search pattern must be a single line")

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -310,13 +310,35 @@ local function add_virtual_cursor_at_real_cursor(down)
   -- Initialise if this is the first cursor
   M.init()
 
-  -- If normal mode
-  if common.is_mode("n") then
+  -- If visual mode
+  if common.is_mode("v") then
 
     -- Add count1 virtual cursors
     local count1 = vim.v.count1
 
     for i = 1, count1 do
+      -- Get the current visual area
+      local v_lnum, v_col, lnum, col, curswant = common.get_visual_area()
+
+      -- Add a virtual cursor with the visual area
+      virtual_cursors.add_with_visual_area(lnum, col, curswant, v_lnum, v_col, true)
+
+      -- Move the real cursor visual area
+      if down then
+        vim.api.nvim_buf_set_mark(0, "<", v_lnum + 1, v_col - 1, {})
+        vim.api.nvim_buf_set_mark(0, ">", lnum + 1, col - 1, {})
+      else
+        vim.api.nvim_buf_set_mark(0, "<", v_lnum - 1, v_col - 1, {})
+        vim.api.nvim_buf_set_mark(0, ">", lnum - 1, col - 1, {})
+      end
+
+      vim.cmd("normal! gv")
+    end
+
+  elseif common.is_mode("n") then  -- If normal mode
+
+    -- Add count1 virtual cursors
+    for i = 1, vim.v.count1 do
       -- Add virtual cursor at the real cursor position
       local pos = vim.fn.getcurpos()
       virtual_cursors.add(pos[2], pos[3], pos[5], true)

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -325,14 +325,10 @@ local function add_virtual_cursor_at_real_cursor(down)
 
       -- Move the real cursor visual area
       if down then
-        vim.api.nvim_buf_set_mark(0, "<", v_lnum + 1, v_col - 1, {})
-        vim.api.nvim_buf_set_mark(0, ">", lnum + 1, col - 1, {})
+        common.set_visual_area(v_lnum + 1, v_col, lnum + 1, col)
       else
-        vim.api.nvim_buf_set_mark(0, "<", v_lnum - 1, v_col - 1, {})
-        vim.api.nvim_buf_set_mark(0, ">", lnum - 1, col - 1, {})
+        common.set_visual_area(v_lnum - 1, v_col, lnum - 1, col)
       end
-
-      vim.cmd("normal! gv")
     end
 
   elseif common.is_mode("n") then  -- If normal mode

--- a/lua/multiple-cursors/search.lua
+++ b/lua/multiple-cursors/search.lua
@@ -103,6 +103,11 @@ function M.get_matches_and_move_cursor(word, limit_to_visible, limit_to_prev_vis
   -- Handle the use_prev_visual_area argument
   local visual_area_end = set_cursor(limit)
 
+  if limit_to_prev_visual_area and not visual_area_end then
+    virtual_cursors.set_ignore_cursor_movement(false)
+    return nil
+  end
+
   -- Find matches
   local matches = {}
 

--- a/lua/multiple-cursors/virtual_cursor.lua
+++ b/lua/multiple-cursors/virtual_cursor.lua
@@ -2,17 +2,17 @@ local VirtualCursor = {}
 
 local common = require("multiple-cursors.common")
 
-function VirtualCursor.new(lnum, col, curswant, first)
+function VirtualCursor.new(lnum, col, curswant, visual_start_lnum, visual_start_col, first)
   local self = setmetatable({}, VirtualCursor)
 
   self.lnum = lnum
   self.col = col
   self.curswant = curswant
 
-  self.first = first                    -- Is this the first cursor added?
+  self.first = first  -- Is this the first cursor added?
 
-  self.visual_start_lnum = 0            -- lnum for the start of the visual area
-  self.visual_start_col = 0             -- col for the start of the visual area
+  self.visual_start_lnum = visual_start_lnum  -- lnum for the start of the visual area
+  self.visual_start_col = visual_start_col    -- col for the start of the visual area
 
   self.mark_id = 0                      -- extmark ID
   self.visual_start_mark_id = 0         -- ID of the hidden extmark that stores the start of the visual area

--- a/lua/multiple-cursors/virtual_cursor.lua
+++ b/lua/multiple-cursors/virtual_cursor.lua
@@ -154,19 +154,7 @@ end
 
 -- Set the visual area from the virtual cursor
 function VirtualCursor:set_visual_area()
-
-  -- Exit visual mode
-  vim.cmd("normal!:")
-
-  -- Set start mark
-  vim.api.nvim_buf_set_mark(0, "<", self.visual_start_lnum, self.visual_start_col - 1, {})
-
-  -- Set end mark
-  vim.api.nvim_buf_set_mark(0, ">", self.lnum, self.col - 1, {})
-
-  -- Return to visual mode
-  vim.cmd("normal! gv")
-
+  common.set_visual_area(self.visual_start_lnum, self.visual_start_col, self.lnum, self.col)
 end
 
 -- Save the register to the virtual cursor

--- a/lua/multiple-cursors/virtual_cursor.lua
+++ b/lua/multiple-cursors/virtual_cursor.lua
@@ -1,5 +1,7 @@
 local VirtualCursor = {}
 
+local common = require("multiple-cursors.common")
+
 function VirtualCursor.new(lnum, col, curswant, first)
   local self = setmetatable({}, VirtualCursor)
 
@@ -60,7 +62,12 @@ function VirtualCursor:is_visual_area_forward()
 end
 
 -- Get the positions of the visual area in a forward direction
-function VirtualCursor:get_normalised_visual_area()
+-- offset is true when getting a visual area for creating extmarks
+function VirtualCursor:get_normalised_visual_area(offset)
+
+  -- offset is false by default
+  offset = offset or false
+
   -- Get start and end positions for the extmarks representing the visual area
   local lnum1 = self.visual_start_lnum
   local col1 = self.visual_start_col
@@ -72,9 +79,15 @@ function VirtualCursor:get_normalised_visual_area()
     col1 = self.col
     lnum2 = self.visual_start_lnum
     col2 = self.visual_start_col
+
+    if offset then
+      -- Add 1 to col2 to include the cursor position
+      col2 = vim.fn.min({col2 + 1, common.get_max_col(lnum2)})
+    end
   end
 
   return lnum1, col1, lnum2, col2
+
 end
 
 -- Less than for sorting

--- a/lua/multiple-cursors/virtual_cursor.lua
+++ b/lua/multiple-cursors/virtual_cursor.lua
@@ -2,14 +2,17 @@ local VirtualCursor = {}
 
 local common = require("multiple-cursors.common")
 
-function VirtualCursor.new(lnum, col, curswant, visual_start_lnum, visual_start_col, first)
+function VirtualCursor.new(lnum, col, curswant, visual_start_lnum, visual_start_col, seq)
   local self = setmetatable({}, VirtualCursor)
 
   self.lnum = lnum
   self.col = col
   self.curswant = curswant
 
-  self.first = first  -- Is this the first cursor added?
+  self.seq = seq  -- Sequence number to store the order that cursors were added
+                  -- When cursors are added with an up/down motion, at exit the
+                  -- real cursor is returned to the position of the oldest
+                  -- virtual cursor
 
   self.visual_start_lnum = visual_start_lnum  -- lnum for the start of the visual area
   self.visual_start_col = visual_start_col    -- col for the start of the visual area

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -54,10 +54,10 @@ function M.sort()
   table.sort(virtual_cursors)
 end
 
--- Add a new virtual cursor
+-- Add a new virtual cursor with a visual area
 -- set_first indicates that the first field should be set to true if this is the first virtual cursor
 -- On exit the cursor position will be set to the virtual cursor which has first = true
-function M.add(lnum, col, curswant, set_first)
+function M.add_with_visual_area(lnum, col, curswant, visual_start_lnum, visual_start_col, set_first)
 
   -- Check for existing virtual cursor
   for _, vc in ipairs(virtual_cursors) do
@@ -68,10 +68,18 @@ function M.add(lnum, col, curswant, set_first)
 
   local first = set_first and #virtual_cursors == 0
 
-  table.insert(virtual_cursors, VirtualCursor.new(lnum, col, curswant, first))
+  table.insert(virtual_cursors, VirtualCursor.new(lnum, col, curswant, visual_start_lnum, visual_start_col, first))
 
   -- Create an extmark
   extmarks.update_virtual_cursor_extmarks(virtual_cursors[#virtual_cursors])
+
+end
+
+-- Add a new virtual cursor
+-- set_first indicates that the first field should be set to true if this is the first virtual cursor
+-- On exit the cursor position will be set to the virtual cursor which has first = true
+function M.add(lnum, col, curswant, set_first)
+  M.add_with_visual_area(lnum, col, curswant, 0, 0, set_first)
 end
 
 -- Add a new virtual cursor, or delete if there's already an existing virtual


### PR DESCRIPTION
For issue #51

The visual area is maintained when adding virtual cursors with an up/down motion, searching for matches, or incrementally adding to matches.