### PR TITLE
Merge registers on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The following commands are supported while using multiple cursors:
 | Visual | Change | `c` | This command is implemented as a delete then switch to insert mode |
 | All | Paste | | [Split pasting](#enable_split_paste) is enabled by default |
 | Insert/replace/visual | Exit to normal mode | `<Esc>` | |
-| Normal | Exit multiple cursors | `<Esc>` | Clears all virtual cursors. <br/> Registers for the virtual cursors will be lost. |
+| Normal | Exit multiple cursors | `<Esc>` | Clears all virtual cursors. <br/> Virtual cursor registers are merged into the real registers. |
 | Normal | Undo | `u` | Also exits multiple cursors, because cursor positions can't be restored by undo |
 
 ### Registers
@@ -140,6 +140,8 @@ The delete, yank, and put commands support named registers in addition to the un
 
 If the put command is used and a virtual cursor doesn't have a register available, the register for the real cursor will be used.
 This means that if you use delete/yank before creating multiple cursors, add cursors, and then use the put command, the same text will be put to each cursor.
+
+When exiting multiple cursors, any virtual cursor register will be merged into the matching real register.
 
 ### Notable unsupported functionality
 

--- a/lua/multiple-cursors/init.lua
+++ b/lua/multiple-cursors/init.lua
@@ -283,19 +283,38 @@ function M.init()
   end
 end
 
+-- Merge all virtual cursor registers into the real cursor register
+local function merge_registers()
+
+  -- Get names of registers stored in virtual cursors
+  local registers = virtual_cursors.get_registers()
+
+  -- For each register
+  for _, register in ipairs(registers) do
+    -- Concatenate
+    virtual_cursors.merge_register_info(register)
+  end
+
+end
+
+-- Restore cursor to the position of the oldest virtual cursor
+local function restore_cursor_position()
+
+  local pos = virtual_cursors.get_exit_pos()
+
+  if pos then
+    vim.fn.cursor({pos[1], pos[2], 0, pos[3]})
+  end
+
+end
+
 -- Deinitialise
 function M.deinit(clear_virtual_cursors)
   if initialised then
 
     if clear_virtual_cursors then
-
-      -- Restore cursor to the position of the oldest virtual cursor
-      local pos = virtual_cursors.get_exit_pos()
-
-      if pos then
-        vim.fn.cursor({pos[1], pos[2], 0, pos[3]})
-      end
-
+      merge_registers()
+      restore_cursor_position()
       virtual_cursors.clear()
       bufnr = nil
       vim.api.nvim_del_autocmd(buf_enter_autocmd_id)


### PR DESCRIPTION
When multiple cursors is exited, virtual cursor registers are merged into the real registers, rather than discarded.