### PR TITLE
fix abnormal motion of main cursor & add highlight for locked state 

### DIFF
--- a/lua/multiple-cursors/extmarks.lua
+++ b/lua/multiple-cursors/extmarks.lua
@@ -1,7 +1,11 @@
 local M = {}
 
 local cursor_hl_group = "MultipleCursorsCursor"
+local lockcursor_hl_group = "MultipleCursorsLockCursor"
 local visual_hl_group = "MultipleCursorsVisual"
+local cursor_hl = nil
+local lockcursor_hl = nil
+local visual_hl = nil
 
 local common = require("multiple-cursors.common")
 
@@ -37,6 +41,16 @@ function M.setup()
     default = true,
   })
 
+  vim.api.nvim_set_hl(0, lockcursor_hl_group, {
+    link = "lCursor",
+    default = true,
+  })
+
+  -- Save default highlight settings
+  cursor_hl     = vim.api.nvim_get_hl(0, {name = cursor_hl_group})
+  lockcursor_hl = vim.api.nvim_get_hl(0, {name = lockcursor_hl_group})
+  visual_hl     = vim.api.nvim_get_hl(0, {name = visual_hl_group})
+
   -- Create a namespace for the extmarks
   highlight_namespace_id = vim.api.nvim_create_namespace("multiple-cursors")
 
@@ -45,6 +59,19 @@ end
 -- Clear all extmarks
 function M.clear()
   vim.api.nvim_buf_clear_namespace(0, highlight_namespace_id, 0, -1)
+end
+
+-- Get default highlight setting
+function M.get_hl(name)
+  if name == cursor_hl_group then
+    return cursor_hl
+  elseif name == lockcursor_hl_group then
+	return lockcursor_hl
+  elseif name == visual_hl_group then
+	return visual_hl
+  else
+	return nil
+  end
 end
 
 local function set_extmark(lnum, col, mark_id, hl_group, priority)

--- a/lua/multiple-cursors/extmarks.lua
+++ b/lua/multiple-cursors/extmarks.lua
@@ -92,8 +92,8 @@ function M.save_cursor()
   local pos = vim.fn.getcurpos()
 
   cursor_lnum = pos[2]  -- Save lnum in case the cursor is lost
-  local col = pos[3]
   cursor_curswant = pos[5]  -- Save curswant
+  local col = vim.fn.virtcol2col(0, cursor_lnum, cursor_curswant)
 
   -- Create an invisible extmark
   cursor_mark_id = set_extmark(cursor_lnum, col, cursor_mark_id, "", 0)
@@ -123,7 +123,7 @@ function M.restore_cursor()
         curswant = col
       end
 
-      vim.fn.cursor({lnum, col, 0, curswant})
+      vim.fn.cursor(lnum, col)
     else
       -- extmark gone, restore from lnum
       vim.fn.cursor({cursor_lnum, 1, 0, 1})

--- a/lua/multiple-cursors/virtual_cursor.lua
+++ b/lua/multiple-cursors/virtual_cursor.lua
@@ -129,14 +129,14 @@ function VirtualCursor:save_cursor_position()
   local pos = vim.fn.getcurpos()
 
   self.lnum = pos[2]
-  self.col = pos[3]
   self.curswant = pos[5]
+  self.col = vim.fn.virtcol2col(0, self.lnum, self.curswant)
 
 end
 
 -- Set the real cursor position from the virtual cursor
 function VirtualCursor:set_cursor_position()
-  vim.fn.cursor({self.lnum, self.col, 0, self.curswant})
+  vim.fn.cursor(self.lnum, self.col)
 end
 
 -- Save the current visual area to the virtual cursor

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -277,7 +277,7 @@ function M.visit_all(func)
   end
 
   -- Restore cursor
-  vim.fn.cursor({cursor_pos[2], cursor_pos[3], cursor_pos[4], cursor_pos[5]})
+  vim.fn.cursor({cursor_pos[2], vim.fn.virtcol2col(0, cursor_pos[2], cursor_pos[5])})
 
   clean_up()
   check_for_collisions()

--- a/lua/multiple-cursors/virtual_cursors.lua
+++ b/lua/multiple-cursors/virtual_cursors.lua
@@ -232,6 +232,14 @@ end
 
 function M.toggle_lock()
   locked = not locked
+
+  local locked_hl = {}
+  if locked then
+    locked_hl = extmarks.get_hl('MultipleCursorsLockCursor') or {}
+  else
+    locked_hl = extmarks.get_hl('MultipleCursorsCursor') or {}
+  end
+  vim.api.nvim_set_hl(0, 'MultipleCursorsCursor', locked_hl)
 end
 
 


### PR DESCRIPTION
1. Problem (fix to #76 )
  1) normal motion in indented line doesn't consider `curswant` when it move to up and down (j ,k)
      it makes main cursor move by the difference between `curswant` and `col` additionally
  2) Cursor's highlight doesn't change when its state changes to locked.

2.  Solution
  1) Considering `curswant`, cursor column number is remained when it moves up and down in indented line
  2) Add `MultipleCursorsLockCursor` to toggle highlight in locked state