### PR TITLE
Add option `nowrap` to not wrap custom_key_maps functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Each element in the `custom_key_maps` table must have three or four elements:
   - "mc" indicates that a motion command and a printable character is requested (e.g. for a surround action)
   - If valid input isn't given by the user the function will not be called
   - There will be no indication that Neovim is waiting for a motion command or character
-  - The "nowrap" option is for using an internal function, e.g. for [alternative keyboard layouts](alternative-keyboard-layouts). Custom key map functions are typically executed for every virtual cursor, but internal functions already do this, so the "nowrap" option causes the given function to be called only once.
+  - The "nowrap" option is for using an internal function, e.g. for [alternative keyboard layouts](#alternative-keyboard-layouts). Custom key map functions are typically executed for every virtual cursor, but internal functions already do this, so the "nowrap" option causes the given function to be called only once.
 
 The following example shows how to use various options for user input:
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Each element in the `custom_key_maps` table must have three or four elements:
   - "mc" indicates that a motion command and a printable character is requested (e.g. for a surround action)
   - If valid input isn't given by the user the function will not be called
   - There will be no indication that Neovim is waiting for a motion command or character
-  - The "nowrap" option is for using an internal function, e.g. for [alternative keyboard layouts](alternative-keyboard-layouts). Custom key map functions are typically be executed for every virtual cursor, but internal functions already do this, so the "nowrap" option causes the given function to be called only once.
+  - The "nowrap" option is for using an internal function, e.g. for [alternative keyboard layouts](alternative-keyboard-layouts). Custom key map functions are typically executed for every virtual cursor, but internal functions already do this, so the "nowrap" option causes the given function to be called only once.
 
 The following example shows how to use various options for user input:
 

--- a/README.md
+++ b/README.md
@@ -251,12 +251,13 @@ Each element in the `custom_key_maps` table must have three or four elements:
 - Mode (string|table): Mode short-name string (`"n"`, `"i"` or `"x"`), or a table of mode short-name strings (for visual mode it's currently only possible to move the cursor)
 - Mapping lhs (string|table): [Left-hand side](https://neovim.io/doc/user/map.html#%7Blhs%7D) of a mapping string, e.g. `">>"`, `"<Tab>"`, or `"<C-/>"`, or a table of lhs strings
 - Function: A Lua function that will be called at each cursor, which receives [`register`](https://neovim.io/doc/user/vvars.html#v%3Aregister) (note: working with virtual cursor registers is not currently implemented), [`count`](https://neovim.io/doc/user/vvars.html#v%3Acount), and optionally more, as arguments. Setting this to `nil` will disable a [default key mapping](#supported-commands).
-- Option: A optional string containing "m", "c", or "mc". These enable getting input from the user, which is then forwarded to the function:
+- Option: A optional string containing "m", "c", "mc", or "nowrap". "m", "c", and "mc" enable getting input from the user, which is then forwarded to the function:
   - "m" indicates that a motion command is requested (i.e. operator pending mode). The motion command can can include a count in addition to the `count` variable.
   - "c" indicates that a printable character is requested (e.g. for character search)
   - "mc" indicates that a motion command and a printable character is requested (e.g. for a surround action)
   - If valid input isn't given by the user the function will not be called
   - There will be no indication that Neovim is waiting for a motion command or character
+  - The "nowrap" option is for using an internal function, e.g. for [alternative keyboard layouts](alternative-keyboard-layouts). Custom key map functions are typically be executed for every virtual cursor, but internal functions already do this, so the "nowrap" option causes the given function to be called only once.
 
 The following example shows how to use various options for user input:
 
@@ -284,6 +285,30 @@ opts = {
     end, "mc"}
   },
 },
+```
+
+### Alternative keyboard layouts
+
+The "nowrap" option for a [custom key map](#custom_key_maps) allows for using internal functions.
+This can be used to remap keys for alternative keyboard layouts, e.g. for the Colemak layout (with the `l` key for changing to insert mode):
+
+```lua
+opts = {
+  custom_key_maps = {
+    -- Remap j, k, and l to n, e, and i
+    {{"n", "x"}, "n", function() require("multiple-cursors.normal_mode.motion").j() end, "nowrap"},
+    {{"n", "x"}, "e", function() require("multiple-cursors.normal_mode.motion").k() end, "nowrap"},
+    {{"n", "x"}, "i", function() require("multiple-cursors.normal_mode.motion").l() end, "nowrap"},
+
+    -- Remap i and I to l and L
+    {{"n", "x"}, "l", function() require("multiple-cursors.normal_mode_mode_change.i() end, "nowrap"},
+    {{"n", "x"}, "L", function() require("multiple-cursors.normal_mode_mode_change.I() end, "nowrap"},
+
+    -- Disable j and k
+    {{"n", "x"}, "j", nil },
+    {{"n", "x"}, "k", nil },
+  }
+}
 ```
 
 ## Plugin compatibility

--- a/lua/multiple-cursors/key_maps.lua
+++ b/lua/multiple-cursors/key_maps.lua
@@ -291,6 +291,8 @@ function M.set_custom()
           wrapped_func = function() custom_function_with_char(func) end
         elseif opt == "mc" then -- Standard character
           wrapped_func = function() custom_function_with_motion_then_char(func) end
+        elseif opt == "nowrap" then
+          wrapped_func = func
         end
       end
 

--- a/lua/multiple-cursors/key_maps.lua
+++ b/lua/multiple-cursors/key_maps.lua
@@ -291,7 +291,7 @@ function M.set_custom()
           wrapped_func = function() custom_function_with_char(func) end
         elseif opt == "mc" then -- Standard character
           wrapped_func = function() custom_function_with_motion_then_char(func) end
-        elseif opt == "nowrap" then
+        elseif opt == "nowrap" then -- For internal functions
           wrapped_func = func
         end
       end


### PR DESCRIPTION
If using the function in the plugin to remap, the `v:count` variable sometimes evals more than once.

![output](https://github.com/user-attachments/assets/fb3887d4-b264-4d3b-917f-5a0bab8f98ca)

This is because of the function is wrapped by default.

```lua
-- key_maps.lua L154
local function custom_function(func)

  -- Save register and count because they may be lost
  local register = vim.v.register
  local count = vim.v.count

  -- Call func for the real cursor
  with_onemore(function() func(register, count) end)

  -- Call func for each virtual cursor
  if common.is_mode("v") then
    virtual_cursors.visual_mode(function(vc)
      func(register, count)
    end)
  else
    virtual_cursors.edit_with_cursor(function(vc)
     func(register, count)
    end)
  end

end
```

For simple modification, add an argument `nowrap` to let the plugin not wrapping the function can prevent from this. 

The config function will look like this.

```lua
    config = function()
      local normal_mode_motion = require("multiple-cursors.normal_mode.motion")
      local normal_mode_edit = require("multiple-cursors.normal_mode.edit")

      local visual_mode_edit = require("multiple-cursors.visual_mode.edit")
      local normal_mode_mode_change = require("multiple-cursors.normal_mode.mode_change")

      local visual_mode_modify_area = require("multiple-cursors.visual_mode.modify_area")
      require("multiple-cursors").setup({
        custom_key_maps = {
          { { "n", "x" }, { "e", "<Up>" }, normal_mode_motion.k, "nowrap" },
          { { "n", "x" }, { "n", "<Down>" }, normal_mode_motion.j, "nowrap" },
          { { "n", "x" }, { "i", "<Right>", "<Space>" }, normal_mode_motion.l, "nowrap" },
          { { "n", "x" }, "j", normal_mode_motion.e, "nowrap" },
          { { "n", "x" }, "J", normal_mode_motion.E, "nowrap" },
          { { "n", "x" }, "gj", normal_mode_motion.ge, "nowrap" },
          { { "n", "x" }, "gJ", normal_mode_motion.gE, "nowrap" },
          { "n", "E", normal_mode_edit.J, "nowrap" },
          { "n", "gE", normal_mode_edit.gJ, "nowrap" },
          { "n", { "l", "<Insert>" }, normal_mode_mode_change.i, "nowrap" },
          { "n", "L", normal_mode_mode_change.I, "nowrap" },
          { "x", "l", visual_mode_modify_area.i, "nowrap" },
          { "x", "E", visual_mode_edit.J, "nowrap" },
          { "x", "gE", visual_mode_edit.gJ, "nowrap" },
        },
      })
    end,

```

## Alternative Way?

Define a new field in `opts`, for example `opts.simple_remap`, that accepts a table for remap only.